### PR TITLE
fix: 2288: Account settings page will not load if user is missing an auth token (API)

### DIFF
--- a/label_studio/users/views.py
+++ b/label_studio/users/views.py
@@ -110,7 +110,11 @@ def user_account(request):
         return redirect(reverse('main'))
 
     form = forms.UserProfileForm(instance=user)
-    token = Token.objects.get(user=user)
+    try:
+        token = Token.objects.get(user=user)
+    except Token.DoesNotExist as e:
+        logger.info(e)
+        token = None
 
     if request.method == 'POST':
         form = forms.UserProfileForm(request.POST, instance=user)


### PR DESCRIPTION
* account page should load even if missing token