### PR TITLE
fix: DEV-2319: Local filenames are not URL encoded

### DIFF
--- a/label_studio/core/views.py
+++ b/label_studio/core/views.py
@@ -215,11 +215,7 @@ def localfiles_data(request):
         if user_has_permissions and os.path.exists(full_path):
             content_type, encoding = mimetypes.guess_type(str(full_path))
             content_type = content_type or 'application/octet-stream'
-            # full_path = "Users/dwright/Documents/datasource/images/test/LSE + + + project import 30K queues.jpeg"
-            response = RangedFileResponse(request, open(full_path, mode='rb'), content_type)
-            return response
-            # from django.http.response import FileResponse
-            # return FileResponse(request, open(full_path, mode='rb'), content_type)
+            return RangedFileResponse(request, open(full_path, mode='rb'), content_type)
         else:
             return HttpResponseNotFound()
 

--- a/label_studio/io_storages/localfiles/models.py
+++ b/label_studio/io_storages/localfiles/models.py
@@ -23,8 +23,6 @@ from tasks.models import Annotation
 
 logger = logging.getLogger(__name__)
 
-NOT_ALLOWED_IN_FILENAME = '[:/\|<>"?*+]'
-
 class LocalFilesMixin(models.Model):
     path = models.TextField(
         _('path'), null=True, blank=True,
@@ -57,11 +55,6 @@ class LocalFilesImportStorage(LocalFilesMixin, ImportStorage):
     def can_resolve_url(self, url):
         return False
 
-    def is_disallowed(self, filename):
-        notallowed = re.compile(NOT_ALLOWED_IN_FILENAME)
-        if notallowed.search(filename):
-            return True
-
     def iterkeys(self):
         path = Path(self.path)
         regex = re.compile(str(self.regex_filter)) if self.regex_filter else None
@@ -70,11 +63,6 @@ class LocalFilesImportStorage(LocalFilesMixin, ImportStorage):
         for file in sorted(path.rglob('*'), key=os.path.basename):
             if file.is_file():
                 key = file.name
-                if self.is_disallowed(key):
-                    raise ValidationError(
-                        f'''Filname contains disallowed character: {NOT_ALLOWED_IN_FILENAME} '''
-                    )
-
                 if regex and not regex.match(key):
                     logger.debug(key + ' is skipped by regex filter')
                     continue

--- a/label_studio/io_storages/localfiles/models.py
+++ b/label_studio/io_storages/localfiles/models.py
@@ -23,6 +23,7 @@ from tasks.models import Annotation
 
 logger = logging.getLogger(__name__)
 
+NOT_ALLOWED_IN_FILENAME = '[:/\|<>"?*+]'
 
 class LocalFilesMixin(models.Model):
     path = models.TextField(
@@ -56,6 +57,11 @@ class LocalFilesImportStorage(LocalFilesMixin, ImportStorage):
     def can_resolve_url(self, url):
         return False
 
+    def is_disallowed(self, filename):
+        notallowed = re.compile(NOT_ALLOWED_IN_FILENAME)
+        if notallowed.search(filename):
+            return True
+
     def iterkeys(self):
         path = Path(self.path)
         regex = re.compile(str(self.regex_filter)) if self.regex_filter else None
@@ -64,6 +70,11 @@ class LocalFilesImportStorage(LocalFilesMixin, ImportStorage):
         for file in sorted(path.rglob('*'), key=os.path.basename):
             if file.is_file():
                 key = file.name
+                if self.is_disallowed(key):
+                    raise ValidationError(
+                        f'''Filname contains disallowed character: {NOT_ALLOWED_IN_FILENAME} '''
+                    )
+
                 if regex and not regex.match(key):
                     logger.debug(key + ' is skipped by regex filter')
                     continue

--- a/label_studio/io_storages/localfiles/models.py
+++ b/label_studio/io_storages/localfiles/models.py
@@ -23,6 +23,7 @@ from tasks.models import Annotation
 
 logger = logging.getLogger(__name__)
 
+
 class LocalFilesMixin(models.Model):
     path = models.TextField(
         _('path'), null=True, blank=True,


### PR DESCRIPTION
* encode url

this is working for most characters

e.g.
```
    "GET /data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie--+--.jpeg HTTP/1.1" 404
    =>
    "GET /data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie--%2B--.jpeg HTTP/1.1" 200
```

however there is still a bug with files containing a `#` in the filename. 

for some reason that is getting stripped early on during `request` construction. I'm having a hard time finding where/when that is happening.

example: filename = `datasource/images/test/curiosity_selfie---#.jpeg`
```
[2022-05-27 17:11:54,292] [io_storages.utils::get_uri_via_regex::25] [WARNING] /data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie---#.jpeg does not match uri regex ([\"'])(?P<uri>(?P<storage>{})://[^\1=]*)\1
[27/May/2022 17:11:54] "GET /data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie--- HTTP/1.1" 404 0
```

```
<WSGIRequest: GET '/data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie---'>
```

```
select * from task
where id = 41452;
--
{
  "$undefined$": "/data/local-files/?d=Users/dwright/Documents/datasource/images/test/curiosity_selfie---#.jpeg"
}
```

