### PR TITLE
fix: remove sensitive token values from debug logs

### DIFF
--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -414,7 +414,7 @@ class OrganizationResetTokenAPI(APIView):
     def post(self, request, *args, **kwargs):
         org = request.user.active_organization
         org.reset_token()
-        logger.debug(f'New token for organization {org.pk} is {org.token}')
+        logger.debug(f'Token reset for organization {org.pk}')
         invite_url = '{}?token={}'.format(reverse('user-signup'), org.token)
         serializer = OrganizationInviteSerializer(data={'invite_url': invite_url, 'token': org.token})
         serializer.is_valid()

--- a/label_studio/users/api.py
+++ b/label_studio/users/api.py
@@ -276,7 +276,7 @@ class UserResetTokenAPI(APIView):
     def post(self, request, *args, **kwargs):
         user = request.user
         token = user.reset_token()
-        logger.debug(f'New token for user {user.pk} is {token.key}')
+        logger.debug(f'Token reset for user {user.pk}')
         return Response({'token': token.key}, status=201)
 
 


### PR DESCRIPTION
Debug log statements in token reset endpoints were logging full token values. Removed token values from log messages while preserving the audit trail of token reset events.