### PR TITLE
fix: Shortcuts does not work (Shift+ArrowKey)

### DIFF
--- a/web/libs/datamanager/src/sdk/hotkeys.ts
+++ b/web/libs/datamanager/src/sdk/hotkeys.ts
@@ -44,7 +44,12 @@ export const useShortcut = (
       // Yield to editor (LSF) hotkeys when the labeling panel is active.
       // The flag is set by Label.jsx when labeling starts and toggled via
       // pointerdown tracking so clicks on the DM table re-enable DM shortcuts.
-      if (document.body.dataset.lsfLabeling === "true") return;
+      if (
+        document.body.dataset.lsfLabeling === "true" &&
+        ["dm.close-labeling", "dm.open-labeling"].includes(actionName)
+      ) {
+        return;
+      }
 
       callback();
     },


### PR DESCRIPTION
This PR fixes: #9639 

### Reason for change
**Problem:** 
Data Manager hotkeys (such as `Shift+Up/Down` for multi-selection) randomly stopped working when navigating datasets if the Label Studio Editor was initialized. Prior updates replaced a focus-based check with a global `document.body.dataset.lsfLabeling = "true"` flag. This inadvertently swallowed **all** keystrokes in `hotkeys.ts`, treating the entire Data Manager interface as inactive whenever the labeling view existed.

**Solution:** 
Modified `useShortcut` in `web/libs/datamanager/src/sdk/hotkeys.ts` to implement an allow-list logic. Instead of blindly ignoring all shortcuts when the dataset flag is active, it now only yields control for explicitly conflicting UI shortcuts (e.g., `["dm.close-labeling", "dm.open-labeling"]`). General table-navigation keys like `Shift+Arrow` are safely passed through to the Data Manager.

### Screenshots
*N/A - Background event listener logic / non-visual change.*

### Rollout strategy
Standard release. No feature flags or environment variables are required.

### Testing
**How verified natively:**
1. Open the Label Studio project / Data Manager.
2. Click on a task to open the Label Studio Editor (LSF side-panel).
3. Click back onto the Data Manager rows to shift focus.
4. Press `Shift+Down` or `Shift+Up`.
5. **Expected result:** Rows are successfully multi-selected (no longer trapped/ignored by the LSF listener).

### Risks
**Low Risk.** We are simply unblocking shortcuts that were originally intended to reach the Data Manager context. Potential conflicts with the Label Studio Editor are handled by explicitly returning early for `dm.close-labeling` and `dm.open-labeling` keys.

### Reviewer notes
This resolves a UX regression likely introduced in recent versions (around `BROS-655`) where the old granular workspace focus mechanism was deprecated in favor of the `dataset.lsfLabeling` check. 

*** ＝ "true"` global state.pointerdown` DOM attribute.

### General notes
File changed: `web/libs/datamanager/src/sdk/hotkeys.ts`