### PR TITLE
docs: Add Azure Blob Storage task syntax example

### DIFF
--- a/docs/source/guide/storage_azure.md
+++ b/docs/source/guide/storage_azure.md
@@ -361,6 +361,18 @@ After adding, click **Sync** to push exports.
 
 </div>
 
+### Create JSON Tasks
+In case you need to create tasks manually to be synchronized as json files, you need to configure the task url with **azure-blob://** prefix like that :
+```json
+{
+  "data":{
+    "image":"azure-blob://<container_name>/<filepath>"
+    ...
+  }
+  ...
+}
+```
+
 
 ## Add storage with the Label Studio API
 


### PR DESCRIPTION
## Reason for change
This PR adds documentation explaining how to manually create JSON tasks that reference Azure Blob Storage URLs using the azure-blob:// protocol prefix. This addresses a gap in our Azure storage documentation for users who need to programmatically create or manually construct task files with Azure Blob Storage references. It's well documented for s3 and standard for google cloud to use gs:// url but not really for azure that's why i suggest to add this documentation.

Currently, the only way to get this information is to analyse unit tests or taxonomy documentation what is definitely not the place where it should be find.

## What's changed
Added a new "Create JSON Tasks" section to the Azure storage guide
Provided a JSON example showing the correct syntax for referencing Azure Blob Storage files in task data structures
Demonstrated the required azure-blob://<container_name>/<filepath> URL format
Documentation updates

The new section appears after the "Validate and troubleshoot" subsection and provides:
- Clear explanation of when this approach is needed (manually created/synchronized JSON tasks)
- Code example with proper JSON structure
- Correct URL format for Azure Blob Storage references

## Testing
Documentation reviewed for clarity and accuracy
Example syntax follows existing Azure Blob Storage URL conventions
Formatting consistent with documentation style guide

## Risks
None — This is a documentation-only change with no impact on code or functionality.
