### PR TITLE
Fix #9633: Tasks won't load with only prediction (no annotation)

### DIFF
--- a/web/libs/editor/src/stores/Annotation/__tests__/store.test.js
+++ b/web/libs/editor/src/stores/Annotation/__tests__/store.test.js
@@ -352,6 +352,19 @@ describe("Annotation store (store.js)", () => {
       expect(childAnn.parent_annotation).toBe(100);
     });
 
+    it("addAnnotationFromPrediction handles numeric result ids without throwing (e.id.replace bug)", () => {
+      const store = createStore();
+      store.initializeStore({});
+      const pred = store.annotationStore.addPrediction({ result: [], pk: "51" });
+      // Simulate a result where id is a number (not a string), which previously caused
+      // "e.id.replace is not a function" when .replace() was called directly on a number.
+      pred._initialAnnotationObj = [{ id: 12345, from_name: "t1", to_name: "t1", type: "labels", value: {} }];
+      expect(() => {
+        const ann = store.annotationStore.addAnnotationFromPrediction(pred);
+        expect(ann).toBeDefined();
+      }).not.toThrow();
+    });
+
     it("createAnnotation with non-interactive prediction result deserializes and selects", () => {
       const store = createStore();
       store.initializeStore({});

--- a/web/libs/editor/src/stores/Annotation/store.js
+++ b/web/libs/editor/src/stores/Annotation/store.js
@@ -534,7 +534,7 @@ const AnnotationStoreModel = types
       // Area id is <uniq-id>#<annotation-id> to be uniq across all tree
       s.forEach((r) => {
         if ("id" in r) {
-          const id = r.id.replace(/#.*$/, `#${c.id}`);
+          const id = String(r.id).replace(/#.*$/, `#${c.id}`);
 
           ids[r.id] = id;
           r.id = id;


### PR DESCRIPTION
Closes #9633

**Reason for change**

Fixes a crash when opening a task that has predictions but no annotations. In `web/libs/editor/src/stores/Annotation/store.js`, the `addAnnotationFromPrediction` action iterates over prediction results and calls `r.id.replace(/#.*$/, ...)` to rewrite area IDs. When a result's `id` field is a number (as returned by some backends), `.replace()` does not exist on the value, producing:

```
Uncaught (in promise) TypeError: e.id.replace is not a function
    addAnnotationFromPrediction store.js:537
```

**Fix**

One-line change in `store.js` line 537:

```js
// before
const id = r.id.replace(/#.*$/, `#${c.id}`);

// after
const id = String(r.id).replace(/#.*$/, `#${c.id}`);
```

Coercing `r.id` to a string before calling `.replace()` handles both string and numeric IDs without changing behavior for the string case.

**Screenshots**

N/A — no visible UI change; the fix restores previously broken behavior (task loads and prediction is applied as a draft annotation).

**Rollout strategy**

No feature flag needed. Pure bug fix with no API or data model changes.

**Testing**

A unit test was added in `web/libs/editor/src/stores/Annotation/__tests__/store.test.js`:

```
"addAnnotationFromPrediction handles numeric result ids without throwing (e.id.replace bug)"
```

The test constructs a prediction whose result contains a numeric `id` (`12345`), calls `addAnnotationFromPrediction`, and asserts no exception is thrown and the returned annotation is defined. This directly reproduces the failing path that caused the crash in production.

Manual verification: opening a task with predictions and no annotations no longer throws in the console and the prediction is correctly loaded into the labeling interface as a draft annotation.

**Risks**

Minimal. `String(value)` on an already-string value is a no-op, so existing behavior for string IDs is unchanged. Numeric IDs are now safely coerced rather than crashing.

**Reviewer notes**

The only changed production line is `store.js:537`. The rest of the diff is the new test case.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*