### PR TITLE
fix: TimeSeries disappearing series lines on zoom

### DIFF
--- a/web/libs/editor/src/components/TimeSeries/TimeSeriesVisualizer.jsx
+++ b/web/libs/editor/src/components/TimeSeries/TimeSeriesVisualizer.jsx
@@ -692,24 +692,21 @@ class TimeSeriesVisualizerD3 extends React.Component {
   initializeChannel(item) {
     const markerId = `marker_${item.id}`;
     const column = item.columnName;
-    const { time, range } = this.props;
+    const { time } = this.props;
     const { margin } = item;
     const height = this.height;
 
     const channel = (this.channels[column] = { id: item.id, units: item.units });
+    const timeBisector = d3.bisector((d) => d[time]).left;
 
-    let { series } = this.props;
+    const fullSeries = this.props.series.filter((x) => x[column] !== null);
+    channel.fullSeries = fullSeries;
+
+    let series = fullSeries;
 
     if (this.optimizedSeries) {
       channel.useOptimizedData = this.useOptimizedData;
-      series = this.optimizedSeries;
-    }
-
-    series = series.filter((x) => {
-      return x[column] !== null;
-    });
-
-    if (this.optimizedSeries) {
+      series = this.optimizedSeries.filter((x) => x[column] !== null);
       channel.optimizedSeries = series;
     }
 
@@ -717,8 +714,8 @@ class TimeSeriesVisualizerD3 extends React.Component {
       return x[column];
     });
 
-    if (!values) {
-      const names = Object.keys(data).filter((name) => name !== time);
+    if (!values || values.length === 0) {
+      const names = Object.keys(this.props.data ?? {}).filter((name) => name !== time);
       const message = `\`${column}\` not found in data. Available columns: ${names.join(
         ", ",
       )}. For headless csv you can use column index`;
@@ -749,9 +746,31 @@ class TimeSeriesVisualizerD3 extends React.Component {
     // line that has representation only on the current range
     channel.lineSlice = d3
       .line()
-      .defined((d) => d[time] >= range[0] && d[time] <= range[1])
+      .defined(
+        (d) =>
+          d &&
+          d[column] !== null &&
+          Number.isFinite(channel.y(d[column])) &&
+          Number.isFinite(channel.x(d[time])),
+      )
       .y((d) => channel.y(d[column]))
       .x((d) => channel.x(d[time]));
+
+    channel.getVisibleSegment = (src, visibleRange) => {
+      if (!src || src.length === 0) return [];
+
+      const start = Math.max(0, timeBisector(src, visibleRange[0]) - 1);
+      const end = Math.min(src.length, timeBisector(src, visibleRange[1]) + 1);
+
+      let segment = src.slice(start, Math.max(start + 2, end));
+
+      if (segment.length < 2) {
+        const pivot = Math.min(src.length - 1, start);
+        segment = src.slice(Math.max(0, pivot - 1), Math.min(src.length, pivot + 2));
+      }
+
+      return segment;
+    };
 
     const marker = this.defs
       .append("marker")
@@ -826,39 +845,55 @@ class TimeSeriesVisualizerD3 extends React.Component {
       channel.x.domain(timerange);
     }
 
-    if (!fixedscale) {
-      // array slice may slow it down, so just find a min-max by ourselves
-      const { data, time } = this.props;
-      const values = data[column];
-      // indices of the first and last displayed values
-      let i = d3.bisectRight(data[time], range[0]);
-      const j = d3.bisectRight(data[time], range[1]);
-      // find min-max
-      let min = values[i];
-      let max = values[i];
+   if (!fixedscale) {
+  const { data, time } = this.props;
+  const values = data[column];
 
-      for (; i < j; i++) {
-        if (min > values[i]) min = values[i];
-        if (max < values[i]) max = values[i];
-      }
+  if (Array.isArray(values) && values.length > 0) {
+    const numericValues = values.filter((v) => v != null && Number.isFinite(v));
+    if (!numericValues.length) return;
 
-      if (channelItem.datarange) {
-        const datarange = channelItem.datarange.split(",");
+    let i = d3.bisectRight(data[time], range[0]);
+    const j = d3.bisectRight(data[time], range[1]);
+    const safeIndex = Math.min(i, values.length - 1);
 
-        if (datarange[0] !== "") min = new Number(datarange[0]);
-        if (datarange[1] !== "") max = new Number(datarange[1]);
-      }
+    let min = values[safeIndex];
+    let max = values[safeIndex];
 
-      // calc scale and shift
-      const [globalMin, globalMax] = d3.extent(values);
-      const diffY = globalMax - globalMin;
-
-      scaleY = diffY / (max - min);
-
-      channel.y.domain([min, max]);
-      // `translateY` relies on the current `y`'s domain so it should be calculated after it
-      translateY = channel.y(globalMin) - channel.y(min);
+    for (; i < j && i < values.length; i++) {
+      const v = values[i];
+      if (v == null || !Number.isFinite(v)) continue;
+      if (!Number.isFinite(min) || min > v) min = v;
+      if (!Number.isFinite(max) || max < v) max = v;
     }
+
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      const [fallbackMin, fallbackMax] = d3.extent(numericValues);
+      min = fallbackMin;
+      max = fallbackMax;
+    }
+
+    if (channelItem.datarange) {
+      const datarange = channelItem.datarange.split(",");
+      if (datarange[0] !== "") min = Number(datarange[0]);
+      if (datarange[1] !== "") max = Number(datarange[1]);
+    }
+
+    if (max === min) {
+      min -= 1;
+      max += 1;
+    }
+
+    const [globalMin, globalMax] = d3.extent(numericValues);
+    const globalSpan = globalMax - globalMin;
+    const domainSpan = max - min;
+
+    scaleY = globalSpan !== 0 && domainSpan !== 0 ? globalSpan / domainSpan : 1;
+
+    channel.y.domain([min, max]);
+    translateY = channel.y(globalMin) - channel.y(min);
+  }
+}
 
     // zoomStep - zoom level when we need to switch between optimized and original data
     const strongZoom = scale > this.zoomStep;
@@ -875,24 +910,19 @@ class TimeSeriesVisualizerD3 extends React.Component {
     }
 
     if (channel.useOptimizedData) {
-      channel.path.attr("transform", `translate(${translate} ${translateY}) scale(${scale} ${scaleY})`);
-      channel.path.attr("transform-origin", `left ${originY}`);
-      channel.path2.attr("d", "");
-    } else {
-      if (channel.optimizedSeries) {
-        channel.path.datum(this.slices[left]);
-        channel.path.attr("d", channel.lineSlice);
-        if (left !== right && this.slices[right]) {
-          channel.path2.datum(this.slices[right]);
-          channel.path2.attr("d", channel.lineSlice);
-        } else {
-          channel.path2.attr("d", "");
-        }
-      } else {
-        channel.path.attr("d", channel.lineSlice);
-        channel.path2.attr("d", "");
-      }
-    }
+  channel.path.attr("transform", `translate(${translate} ${translateY}) scale(${scale} ${scaleY})`);
+  channel.path.attr("transform-origin", `left ${originY}`);
+  channel.path2.attr("d", "");
+} else {
+  channel.path.attr("transform", "");
+
+  const visibleSeries = channel.getVisibleSegment(channel.fullSeries, range);
+
+  channel.path.datum(visibleSeries);
+  channel.path.attr("d", visibleSeries.length >= 2 ? channel.lineSlice : null);
+
+  channel.path2.attr("d", "");
+}
 
     this.renderXAxis();
     this.renderYAxis();


### PR DESCRIPTION
## Reason for change

This PR fixes a TimeSeries rendering issue where some channels disappear while zooming, and the rendered SVG `<path>` ends up with an empty `d=""` attribute.

Observed behavior:
- while zooming into a narrow range, some series become invisible
- in DevTools, the corresponding SVG path is rendered as `<path ... d=""></path>`

This appears related to:
- Fixes #2900
- Fixes #1752

Root cause:
- the zoomed line rendering path could be built from sparse/optimized slices that did not contain enough valid points for the current visible range
- when that happened, the D3 line generator produced an empty path

Solution:
- preserve the full filtered series for each channel
- build the zoom-visible segment from the full channel series instead of relying on pre-sliced zoom buckets
- include neighboring boundary points around the visible range so narrow zoom windows still produce a valid line segment
- add guards for degenerate Y-scaling cases and invalid numeric values

## What changed

In `TimeSeriesVisualizer.jsx`:
- store `channel.fullSeries` for each channel
- add `channel.getVisibleSegment(...)` to derive the visible segment from the full series using a bisector
- render the zoomed path from `channel.fullSeries` instead of `this.slices[left/right]`
- guard Y-scale recalculation against null / non-finite values and flat segments

In `Channel.jsx`:
- include related `multiaxis` handling changes so the visualizer receives the expected set of channels when rendering shared charts

## Screenshots / Representation

https://github.com/user-attachments/assets/44ab221f-5195-4db1-829f-14f089142b3c

https://github.com/user-attachments/assets/9e230494-04ee-4ef1-b471-ad13325ee85c

## Rollout strategy

No feature flag.
This is a direct bug fix to TimeSeries rendering behavior.

## Testing

Manual verification performed locally:
- opened a TimeSeries project with affected data
- zoomed repeatedly into narrow ranges where some channels previously disappeared
- checked the rendered SVG in DevTools
- verified that the affected paths no longer collapse to `d=""` in the tested cases

Additional validation performed:
- confirmed that normal non-zoomed rendering still works
- confirmed that the code still handles optimized/full-series switching
- confirmed that narrow visible windows still render using boundary points from the full series

## Risks

Low to moderate.

Potential risks:
- slight performance impact during zoom because the visible segment is now derived from the full channel series instead of relying entirely on sparse slices
- edge-case behavior may change for extremely large datasets with many channels
- multiaxis behavior should be reviewed carefully because channel aggregation affects shared rendering paths

Risk mitigations:
- only a small visible segment is extracted from the full series
- optimized rendering is still used outside the narrow zoom-path case
- changes are limited to TimeSeries rendering logic

## Reviewer notes

The most important logic is in:
- `initializeChannel(...)`
- `setChannelRangeWithScaling(...)`

Please review:
- how `channel.fullSeries` is constructed
- how `channel.getVisibleSegment(...)` selects boundary points
- the switch away from rendering zoom paths from `this.slices[left/right]`

## General notes

This fix targets the specific failure mode where D3 receives too few valid points for the current visible range and emits an empty SVG path.

The intended behavior after this change is:
- channels remain visible while zooming
- the SVG path for visible data remains valid
- narrow zoom ranges still render a line if neighboring points exist

Overall fixes performed by ChatGPT, I barely did any review of source code.


