### PR TITLE
fix: allow deleting predictions with missing model version

### DIFF
--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -883,9 +883,9 @@ class ProjectModelVersions(generics.RetrieveAPIView):
         project = self.get_object()
         model_version = request.data.get('model_version', None)
 
-        if not model_version:
-            raise RestValidationError('model_version param is required')
-
+        if model_version == 'undefined' or model_version == 'null':
+            model_version = None
+        
         count = project.delete_predictions(model_version=model_version)
 
         return Response(data=count)

--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -807,7 +807,9 @@ class Project(ProjectMixin, FsmHistoryStateModel):
         """
         params = {'project': self}
 
-        if model_version:
+        if model_version is None or model_version == 'undefined':
+            params.update({'model_version__isnull': True})
+        else:
             params.update({'model_version': model_version})
 
         predictions = Prediction.objects.filter(**params)


### PR DESCRIPTION
**Summary**
Fixes issue #9717 where predictions from imported tasks couldn't be deleted due to a missing `model_version`.

**Changes**
- `api.py`: Made `model_version` optional and added handling for `undefined`/`null` strings sent by the frontend.
- `models.py`: Updated `delete_predictions` to use `model_version__isnull=True` when targeting null versions.

**Testing**
Verified via `curl` to simulate the React frontend payload:
- Command: `curl -X DELETE ... -d '{"model_version": "undefined"}'`
- Result: Returns `200 OK` and `{"deleted_predictions": X}`.
- Logs: Server successfully processes the request without the previous `RestValidationError`.

**Screenshots**
1. Terminal 1 (Server Logs): Shows the `DELETE` request returning a successful 200 status code instead of a 400 validation error
<img width="1474" height="364" alt="image" src="https://github.com/user-attachments/assets/aceb94ff-58f3-489e-83b5-a2ac2fa58bbf" />

2. Terminal 2 (Client Response): Confirms the API successfully accepts `undefined `as a version and returns a valid count of deleted predictions
<img width="1232" height="192" alt="image" src="https://github.com/user-attachments/assets/abd18550-2fc5-43b0-886b-568565bc35d0" />
