### PR TITLE
fix: N+1 query on GET /api/users list endpoint [#9761]

### DIFF
--- a/label_studio/users/api.py
+++ b/label_studio/users/api.py
@@ -179,7 +179,11 @@ class UserAPI(viewsets.ModelViewSet):
     http_method_names = ['get', 'post', 'head', 'patch', 'delete']
 
     def get_queryset(self):
-        return User.objects.filter(organizations=self.request.user.active_organization)
+        return (
+            User.objects.filter(organizations=self.request.user.active_organization)
+            .select_related('active_organization', 'active_organization__created_by')
+            .prefetch_related('om_through')
+        )
 
     @extend_schema(exclude=True)
     @action(detail=True, methods=['delete', 'post'], permission_required=all_permissions.avatar_any)

--- a/label_studio/users/tests/test_users_api.py
+++ b/label_studio/users/tests/test_users_api.py
@@ -1,0 +1,66 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from organizations.models import Organization, OrganizationMember
+from rest_framework import status
+from rest_framework.test import APIClient
+from users.tests.factories import UserFactory
+
+
+class UserListQueryOptimizationTest(TestCase):
+    """Test that GET /api/users uses select_related/prefetch_related to avoid N+1 queries."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.owner = UserFactory()
+        self.org = Organization.create_organization(created_by=self.owner, title='Test Org')
+        self.owner.active_organization = self.org
+        self.owner.save(update_fields=['active_organization'])
+        OrganizationMember.objects.get_or_create(user=self.owner, organization=self.org)
+        self.client.force_authenticate(user=self.owner)
+
+    def _create_users(self, count: int) -> list:
+        return [UserFactory(active_organization=self.org) for _ in range(count)]
+
+    def test_list_query_count_does_not_scale_with_user_count(self):
+        """The number of queries should be constant regardless of how many users are in the org."""
+        self._create_users(5)
+        with self.assertNumQueries(3) as ctx_small:
+            response_small = self.client.get(reverse('user-list'))
+        self.assertEqual(response_small.status_code, status.HTTP_200_OK)
+        baseline = len(ctx_small.captured_queries)
+
+        self._create_users(20)
+        with self.assertNumQueries(baseline):
+            response_large = self.client.get(reverse('user-list'))
+        self.assertEqual(response_large.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_large.data), 26)
+
+    def test_list_returns_active_organization_meta(self):
+        """Verify that active_organization_meta is populated correctly with prefetch."""
+        self._create_users(3)
+        response = self.client.get(reverse('user-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for user_data in response.data:
+            self.assertIn('active_organization_meta', user_data)
+            meta = user_data['active_organization_meta']
+            self.assertIn('title', meta)
+            self.assertIn('email', meta)
+
+    def test_list_deleted_member_shown_as_deleted(self):
+        """Verify that soft-deleted org members are shown as 'Deleted User' with prefetch."""
+        users = self._create_users(2)
+        om = OrganizationMember.objects.get(user=users[0], organization=self.org)
+        om.soft_delete()
+
+        response = self.client.get(reverse('user-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        deleted_user_data = next(u for u in response.data if u['id'] == users[0].id)
+        self.assertEqual(deleted_user_data['first_name'], 'Deleted')
+        self.assertEqual(deleted_user_data['last_name'], 'User')
+
+    def test_retrieve_still_works(self):
+        """Verify that GET /api/users/<id> still works with the optimized queryset."""
+        users = self._create_users(1)
+        response = self.client.get(reverse('user-detail', args=[users[0].id]))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], users[0].id)


### PR DESCRIPTION
## Description

Fix for issue [N+1 query on GET /api/users list endpoint #9761](https://github.com/HumanSignal/label-studio/issues/9761) 

`GET /api/users` suffers from N+1 queries. For each user returned, `BaseUserSerializer` triggers additional queries to resolve:

1. `active_organization` (FK on User) - 1 query per user
2. `active_organization.created_by` (FK on Organization) - 1 query per user
3. `om_through` (reverse FK, OrganizationMember) - 1 query per user

For an org with 151 users, this produces **605 queries** and ~1.5s response time. The query count grows linearly with the number of users.

This is the same pattern that was fixed for the organization members endpoint in PR #7461.

### Fix

Add `select_related` and `prefetch_related` to `UserAPI.get_queryset()`:

```python
def get_queryset(self):
    return (
        User.objects.filter(organizations=self.request.user.active_organization)
        .select_related('active_organization', 'active_organization__created_by')
        .prefetch_related('om_through')
    )
```

This reduces the query count to a **constant 3 queries** regardless of user count:
1. Auth/permission check
2. Main user query with JOINs (select_related)
3. Batch prefetch of organization memberships (prefetch_related)

### Reproduction

```python
from django.test.utils import CaptureQueriesContext
from django.db import connection

with CaptureQueriesContext(connection) as ctx:
    response = client.get('/api/users')
print(f'{len(ctx.captured_queries)} queries for {len(response.json())} users')
# Before: 605 queries for 151 users
# After:    3 queries for 151 users
```

## Acceptance Criteria

- When a user calls `GET /api/users`, the number of SQL queries is constant regardless of how many users are in the organization.
- When a user calls `GET /api/users`, the `active_organization_meta` field is correctly populated for each user.
- When a user calls `GET /api/users` and a member has been soft-deleted, that user appears as "Deleted User".
- When a user calls `GET /api/users/<id>`, the response is unchanged.

## Tests

Added `label_studio/users/tests/test_users_api.py` with 4 test cases:

| Test | What it verifies |
|------|-----------------|
| `test_list_query_count_does_not_scale_with_user_count` | Query count stays constant (3) when scaling from 6 to 26 users |
| `test_list_returns_active_organization_meta` | `active_organization_meta` contains `title` and `email` for all users |
| `test_list_deleted_member_shown_as_deleted` | Soft-deleted org members render as "Deleted User" |
| `test_retrieve_still_works` | Single-user retrieve endpoint is unaffected |

All tests pass on both sqlite and postgresql (tested locally against postgres:16-alpine).

**Note on tavern:** Contributing guidelines recommend tavern for API endpoint tests. We used Django `TestCase` with `assertNumQueries` instead because the core assertion — that query count is constant regardless of user count — cannot be expressed in tavern. The tests still exercise the full DRF request/response cycle via `APIClient`.

## Risks

**Low risk.** The change is a single queryset optimization — no new models, migrations, endpoints, or behavioral changes.

- `select_related` / `prefetch_related` are standard Django ORM and database-agnostic. They change how queries are batched, not what data is returned.
- The same pattern was applied to the organization members endpoint in #7461 without issues.
- `get_queryset()` is shared by all `UserAPI` actions (list, retrieve, create, update, delete). The extra JOINs and prefetch add negligible overhead for single-object operations (retrieve, update, delete) and are a net improvement for list.
- No feature flag needed — this is a pure performance fix with no behavioral change to the API response.

