### PR TITLE
docs: clarify automatic task assignment wording in Project settings

### DIFF
--- a/docs/source/guide/project_settings_lse.md
+++ b/docs/source/guide/project_settings_lse.md
@@ -242,8 +242,7 @@ Select how you want to handle skipped tasks. To disallow skipping tasks, you can
 If an annotator skips a task, the task is moved to the bottom of their queue. They see the task again as they reach the end of their queue. 
 
 If the annotator exits the label stream without labeling the skipped task, and then later re-enters the label stream, whether they see the task again depends on how task assignments are set up. 
-
-* Automatic task assignment: Whether they see the task again depends on if other annotators have since completed the task. If the task is still incomplete when the annotator re-enters the labeling stream, they can update label and re-submit the task. 
+* Automatic task assignment: Whether they see the task again depends on whether other annotators have since completed the task or not. If the task is still incomplete when the annotator re-enters the labeling stream, they can update the labels and re-submit the task. 
 * Manual task assignment: The annotator will continue to see the skipped task until it is completed.  
 
 Skipped tasks are not marked as completed, and affect the Overall Project Progress calculation visible from the project Dashboard. (Meaning that the progress for a project that has skipped tasks will be less than 100%.)  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reason for change:
- Clarifies phrasing under "Skip Queue > Requeue skipped tasks back to the annotator" for Automatic task assignment.

What changed:
- Replaced "if" with "whether" and added "or not" for clarity and correctness.
- Fixed grammar from "update label" to "update the labels".

Verification:
- Built locally not required for simple markdown wording; the edit preserves existing markdown structure and list formatting in `docs/source/guide/project_settings_lse.md`.

Risks:
- Low; docs-only change.

Notes for reviewers:
- File edited: `docs/source/guide/project_settings_lse.md`.
- Section: Annotation > Skip Queue > Requeue skipped tasks back to the annotator.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://humansignal.slack.com/archives/C01HGFXA7KR/p1779897545710109?thread_ts=1779897545.710109&cid=C01HGFXA7KR)

<div><a href="https://cursor.com/agents/bc-4e842c9e-8f0d-5e96-b7b0-46c182823ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e842c9e-8f0d-5e96-b7b0-46c182823ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

