### PR TITLE
feat: freehand polygon drawing (press-and-drag) behind feature flag

### DIFF
--- a/docs/source/tags/polygon.md
+++ b/docs/source/tags/polygon.md
@@ -16,7 +16,7 @@ Use with the following data types: image.
 
 When the `fflag_feat_front_polygon_freehand` feature flag is enabled, select the Polygon tool and press and drag to draw a contour with a mouse, pen, or primary touch. The contour is simplified when the pointer is released and is saved as one undoable polygon.
 
-To repair part of an existing polygon, select it with the Polygon tool, then drag from one contour edge to another. The traced path replaces the matching section of the contour and is saved as one undoable edit. Start and finish near the edge; releasing away from the contour cancels the repair. Point handles, polygon movement, and a short edge click keep their existing behavior.
+To repair part of an existing polygon, select it with the Polygon tool, then drag from one contour edge to another. The traced path replaces the matching section of the contour and is saved as one undoable edit. Start and finish near the edge; releasing away from the contour cancels the repair. Repair takes precedence near the contour; drag from the polygon interior to move the whole polygon. A short edge click keeps the existing point-insertion behavior.
 
 The flag is off by default; with it disabled, the existing click-to-place and point-editing behaviors are unchanged.
 

--- a/docs/source/tags/polygon.md
+++ b/docs/source/tags/polygon.md
@@ -14,7 +14,11 @@ Use with the following data types: image.
 
 ### Freehand drawing
 
-When the `fflag_feat_front_polygon_freehand` feature flag is enabled, select the Polygon tool and press and drag to draw a contour with a mouse, pen, or primary touch. The contour is simplified when the pointer is released and is saved as one undoable polygon. The flag is off by default; with it disabled, the existing click-to-place behavior is unchanged.
+When the `fflag_feat_front_polygon_freehand` feature flag is enabled, select the Polygon tool and press and drag to draw a contour with a mouse, pen, or primary touch. The contour is simplified when the pointer is released and is saved as one undoable polygon.
+
+To repair part of an existing polygon, select it with the Polygon tool, then drag from one contour edge to another. The traced path replaces the matching section of the contour and is saved as one undoable edit. Start and finish near the edge; releasing away from the contour cancels the repair. Point handles, polygon movement, and a short edge click keep their existing behavior.
+
+The flag is off by default; with it disabled, the existing click-to-place and point-editing behaviors are unchanged.
 
 ### Example
 

--- a/docs/source/tags/polygon.md
+++ b/docs/source/tags/polygon.md
@@ -12,6 +12,10 @@ Use with the following data types: image.
 
 {% insertmd includes/tags/polygon.md %}
 
+### Freehand drawing
+
+When the `fflag_feat_front_polygon_freehand` feature flag is enabled, select the Polygon tool and press and drag to draw a contour with a mouse, pen, or primary touch. The contour is simplified when the pointer is released and is saved as one undoable polygon. The flag is off by default; with it disabled, the existing click-to-place behavior is unchanged.
+
 ### Example
 
 Basic labeling configuration for polygonal image segmentation

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -30,6 +30,7 @@ import {
   FREEHAND_REPAIR_SNAP_RADIUS,
   FREEHAND_SIMPLIFY_EPSILON,
   buildFreehandRepairContour,
+  findNearestContourPoint,
   isValidFreehandContour,
   simplifyFreehandPoints,
 } from "../../utils/freehand";
@@ -580,7 +581,7 @@ export default observer(
       return tool?.toolName === "PolygonTool" && tool.canStartFreehand && tool.commitFreehand ? tool : null;
     };
 
-    getFreehandRepairTarget = (target, tool, event) => {
+    getFreehandRepairTarget = (target, tool, event, canvasPoint) => {
       if (event?.metaKey || event?.ctrlKey || event?.altKey || event?.shiftKey) return null;
 
       const { item } = this.props;
@@ -607,7 +608,19 @@ export default observer(
         node = node.getParent?.() ?? node.parent ?? null;
       }
 
-      return belongsToRegion && Number.isInteger(edgeIndex) ? { region, edgeIndex } : null;
+      // Dense contours commonly hit an anchor, the fill, or the stage instead of
+      // the invisible edge helper. Resolve the intent from contour geometry while
+      // retaining the normal interaction of unrelated regions and the polygon
+      // interior.
+      if (!belongsToRegion && !this.isToolInteractionTarget(target)) return null;
+      const nearest = findNearestContourPoint(this.getFreehandRepairContour(region), canvasPoint);
+      const zoom = Number.isFinite(item.zoomScale) && item.zoomScale > 0 ? item.zoomScale : 1;
+
+      if (!nearest || nearest.distance > FREEHAND_REPAIR_SNAP_RADIUS / zoom) return null;
+
+      // Keep the hit-tested edge index only for the stock short-click insertion
+      // path; drag endpoints are validated geometrically when committed.
+      return { region, edgeIndex: belongsToRegion && Number.isInteger(edgeIndex) ? edgeIndex : null };
     };
 
     getFreehandRepairContour = (region) =>
@@ -615,20 +628,23 @@ export default observer(
         ({ x, y }) => Number.isFinite(x) && Number.isFinite(y),
       );
 
-    suspendFreehandRepairDragging = (region) => {
-      const node = region?.shapeRef;
+    suspendFreehandRepairDragging = (region, target) => {
+      const nodes = [region?.shapeRef, target].filter(
+        (node, index, candidates) => node?.draggable && candidates.indexOf(node) === index,
+      );
 
-      if (!node?.draggable) return;
-      this.freehandRepairDragState = { node, draggable: node.draggable() };
-      node.stopDrag?.();
-      node.draggable(false);
+      this.freehandRepairDragState = nodes.map((node) => ({ node, draggable: node.draggable() }));
+      this.freehandRepairDragState.forEach(({ node }) => {
+        node.stopDrag?.();
+        node.draggable(false);
+      });
     };
 
     restoreFreehandRepairDragging = () => {
       const dragState = this.freehandRepairDragState;
 
       this.freehandRepairDragState = null;
-      if (dragState?.node?.draggable) dragState.node.draggable(dragState.draggable);
+      dragState?.forEach(({ node, draggable }) => node.draggable?.(draggable));
     };
 
     insertFreehandRepairPoint = (event) => {
@@ -836,35 +852,22 @@ export default observer(
       if (this.freehandPointerId !== null || event.isPrimary === false || (event.button ?? 0) !== 0) return;
 
       const tool = this.getFreehandTool();
-      const repairTarget = this.getFreehandRepairTarget(eventLike.target, tool, event);
-
-      if (!repairTarget && !tool?.canStartFreehand()) return;
-
+      if (!tool) return;
       const { item } = this.props;
 
       item.updateSkipInteractions(eventLike);
       if (item.annotation.isReadOnly()) return;
       if (eventLike.target?.getParent?.()?.className === "Transformer") return;
-      if (!repairTarget && !this.isToolInteractionTarget(eventLike.target)) return;
 
       const point = this.getFreehandPoint(event);
 
       if (!point) return;
+      const repairTarget = this.getFreehandRepairTarget(eventLike.target, tool, event, point.canvas);
 
-      let initialCanvasPoint = point.canvas;
+      if (!repairTarget && !tool?.canStartFreehand()) return;
+      if (!repairTarget && !this.isToolInteractionTarget(eventLike.target)) return;
 
       if (repairTarget) {
-        const contour = this.getFreehandRepairContour(repairTarget.region);
-        const edgeStart = contour[repairTarget.edgeIndex];
-        const edgeEnd = contour[(repairTarget.edgeIndex + 1) % contour.length];
-        const anchor = edgeStart && edgeEnd ? projectPointToEdge(point.canvas, edgeStart, edgeEnd) : null;
-        const zoom = Number.isFinite(item.zoomScale) && item.zoomScale > 0 ? item.zoomScale : 1;
-        const anchorDistanceSquared = anchor
-          ? (anchor.x - point.canvas.x) ** 2 + (anchor.y - point.canvas.y) ** 2
-          : Number.POSITIVE_INFINITY;
-
-        if (!anchor || anchorDistanceSquared > (FREEHAND_REPAIR_SNAP_RADIUS / zoom) ** 2) return;
-        initialCanvasPoint = anchor;
         event.preventDefault?.();
         eventLike.cancelBubble = true;
       }
@@ -877,11 +880,11 @@ export default observer(
       this.freehandRepairEdgeIndex = repairTarget?.edgeIndex ?? null;
       this.freehandTrace = appendFreehandPoint([], {
         ...point.screen,
-        canvas: initialCanvasPoint,
+        canvas: point.canvas,
         internal: point.internal,
       });
-      this.setState({ freehandPoints: [initialCanvasPoint.x, initialCanvasPoint.y] });
-      if (repairTarget) this.suspendFreehandRepairDragging(repairTarget.region);
+      this.setState({ freehandPoints: [point.canvas.x, point.canvas.y] });
+      if (repairTarget) this.suspendFreehandRepairDragging(repairTarget.region, eventLike.target);
 
       const captureTarget = this.props.item.stageRef?.content;
 

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -558,6 +558,35 @@ export default observer(
       return tool?.toolName === "PolygonTool" && tool.canStartFreehand && tool.commitFreehand ? tool : null;
     };
 
+    isRightElementToCatchToolInteractions = (element, isMoveTool) => {
+      // Bitmask is like Brush, so treat it the same. The only difference is
+      // that Bitmask doesn't have a group inside.
+      if (element.nodeType === "Layer" && !isMoveTool && element.attrs?.name === "bitmask") return true;
+
+      if (element.nodeType === "Group") {
+        // It could be ruler or segmentation.
+        if (element.attrs?.name === "ruler") return true;
+
+        // Segmentation is specific for Brushes, but click interaction on the
+        // region covers the same MoveTool interaction, so ignore MoveTool here
+        // to prevent conflicts.
+        if (!isMoveTool && element.attrs?.name === "segmentation") return true;
+      }
+
+      return false;
+    };
+
+    isToolInteractionTarget = (target, isMoveTool = false) => {
+      const { item } = this.props;
+
+      if (!target) return false;
+      return (
+        item.getSkipInteractions() ||
+        target === item.stageRef ||
+        findClosestParent(target, (element) => this.isRightElementToCatchToolInteractions(element, isMoveTool))
+      );
+    };
+
     getFreehandPoint = (event) => {
       const { item } = this.props;
       const stage = item.stageRef;
@@ -681,6 +710,13 @@ export default observer(
       const tool = this.getFreehandTool();
 
       if (!tool?.canStartFreehand()) return;
+
+      const { item } = this.props;
+
+      item.updateSkipInteractions(eventLike);
+      if (item.annotation.isReadOnly()) return;
+      if (eventLike.target?.getParent?.()?.className === "Transformer") return;
+      if (!this.isToolInteractionTarget(eventLike.target)) return;
 
       const point = this.getFreehandPoint(event);
 
@@ -860,34 +896,7 @@ export default observer(
           e.evt.preventDefault();
         }
 
-        const isRightElementToCatchToolInteractions = (el) => {
-          // Bitmask is like Brush, so treat it the same
-          // The only difference is that Bitmask doesn't have a group inside
-          if (el.nodeType === "Layer" && !isMoveTool && el.attrs?.name === "bitmask") {
-            return true;
-          }
-
-          // It could be ruler ot segmentation
-          if (el.nodeType === "Group") {
-            if (el?.attrs?.name === "ruler") {
-              return true;
-            }
-            // segmentation is specific for Brushes
-            // but click interaction on the region covers the case of the same MoveTool interaction here,
-            // so it should ignore move tool interaction to prevent conflicts
-            if (!isMoveTool && el?.attrs?.name === "segmentation") {
-              return true;
-            }
-          }
-          return false;
-        };
-
-        if (
-          // create regions over another regions with Cmd/Ctrl pressed
-          item.getSkipInteractions() ||
-          e.target === item.stageRef ||
-          findClosestParent(e.target, isRightElementToCatchToolInteractions)
-        ) {
+        if (this.isToolInteractionTarget(e.target, isMoveTool)) {
           window.addEventListener("mousemove", this.handleGlobalMouseMove);
           window.addEventListener("mouseup", this.handleGlobalMouseUp);
           const { offsetX: x, offsetY: y } = e.evt;
@@ -1426,6 +1435,8 @@ const EntireStage = observer(
     crosshairRef,
   }) => {
     const { store } = item;
+    const selectedTool = item.getToolsManager().findSelectedTool();
+    const freehandEnabled = isFF(FF_POLYGON_FREEHAND) && selectedTool?.toolName === "PolygonTool";
     let size;
     let position;
 
@@ -1454,7 +1465,7 @@ const EntireStage = observer(
         className={[
           styles["image-element"],
           ...imagePositionClassnames,
-          isFF(FF_POLYGON_FREEHAND) ? styles["freehand-enabled"] : null,
+          freehandEnabled ? styles["freehand-enabled"] : null,
         ]
           .filter(Boolean)
           .join(" ")}

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -34,7 +34,7 @@ Konva.showWarnings = false;
 
 const hotkeys = Hotkey("Image");
 const imgDefaultProps = { crossOrigin: "anonymous" };
-const FREEHAND_COMPATIBILITY_GUARD_MS = 500;
+const FREEHAND_COMPATIBILITY_GUARD_MS = 1500;
 const FREEHAND_COMPATIBILITY_GUARD_DISTANCE = 25;
 const FREEHAND_DRAG_THRESHOLD = 5;
 
@@ -543,6 +543,7 @@ export default observer(
     freehandTrace = [];
     freehandDragging = false;
     freehandCompatibilityGuard = null;
+    freehandCompatibilityClock = Date.now;
 
     constructor(props) {
       super(props);
@@ -677,7 +678,7 @@ export default observer(
       this.freehandCompatibilityGuard = {
         clientX,
         clientY,
-        expiresAt: Date.now() + FREEHAND_COMPATIBILITY_GUARD_MS,
+        expiresAt: this.freehandCompatibilityClock() + FREEHAND_COMPATIBILITY_GUARD_MS,
       };
     };
 
@@ -687,7 +688,11 @@ export default observer(
 
       const guard = this.freehandCompatibilityGuard;
 
-      if (!guard || Date.now() > guard.expiresAt) return false;
+      if (!guard) return false;
+      if (this.freehandCompatibilityClock() >= guard.expiresAt) {
+        this.freehandCompatibilityGuard = null;
+        return false;
+      }
 
       const clientX = Number.isFinite(event?.clientX) ? event.clientX : event?.offsetX;
       const clientY = Number.isFinite(event?.clientY) ? event.clientY : event?.offsetY;

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -20,14 +20,23 @@ import ResizeObserver from "../../utils/resize-observer";
 import { debounce } from "@humansignal/core/lib/utils/debounce";
 import Constants from "../../core/Constants";
 import { fixRectToFit, mapKonvaBrightness } from "../../utils/image";
-import { FF_DEV_1442, FF_LSDV_4930, FF_ZOOM_OPTIM, isFF } from "../../utils/feature-flags";
+import { FF_DEV_1442, FF_LSDV_4930, FF_POLYGON_FREEHAND, FF_ZOOM_OPTIM, isFF } from "../../utils/feature-flags";
 import { Pagination } from "../../common/Pagination/Pagination";
 import { Image } from "./Image";
+import {
+  appendFreehandPoint,
+  FREEHAND_MIN_DISTANCE,
+  FREEHAND_SIMPLIFY_EPSILON,
+  simplifyFreehandPoints,
+} from "../../utils/freehand";
 
 Konva.showWarnings = false;
 
 const hotkeys = Hotkey("Image");
 const imgDefaultProps = { crossOrigin: "anonymous" };
+const FREEHAND_COMPATIBILITY_GUARD_MS = 500;
+const FREEHAND_COMPATIBILITY_GUARD_DISTANCE = 25;
+const FREEHAND_DRAG_THRESHOLD = 5;
 
 export const splitRegions = (regions) => {
   const brushRegions = [];
@@ -516,6 +525,7 @@ export default observer(
     state = {
       imgStyle: {},
       pointer: [0, 0],
+      freehandPoints: [],
     };
 
     imageRef = createRef();
@@ -527,6 +537,12 @@ export default observer(
     skipNextMouseUp = false;
     mouseDownPoint = null;
     mouseDown = false;
+    freehandPointerId = null;
+    freehandCaptureTarget = null;
+    freehandTool = null;
+    freehandTrace = [];
+    freehandDragging = false;
+    freehandCompatibilityGuard = null;
 
     constructor(props) {
       super(props);
@@ -535,8 +551,212 @@ export default observer(
         props.store.settings.setSmoothing(props.item.smoothingEnabled);
     }
 
+    getFreehandTool = () => {
+      if (!isFF(FF_POLYGON_FREEHAND)) return null;
+      const tool = this.props.item.getToolsManager().findSelectedTool();
+
+      return tool?.toolName === "PolygonTool" && tool.canStartFreehand && tool.commitFreehand ? tool : null;
+    };
+
+    getFreehandPoint = (event) => {
+      const { item } = this.props;
+      const stage = item.stageRef;
+
+      if (!stage) return null;
+      if (Number.isFinite(event?.clientX) && Number.isFinite(event?.clientY)) stage.setPointersPositions(event);
+
+      const screen = stage.getPointerPosition();
+
+      if (!screen || !Number.isFinite(screen.x) || !Number.isFinite(screen.y)) return null;
+
+      const [canvasX, canvasY] = item.fixZoomedCoords([screen.x, screen.y]);
+
+      return {
+        screen,
+        canvas: { x: canvasX, y: canvasY },
+        internal: [item.canvasToInternalX(canvasX), item.canvasToInternalY(canvasY)],
+      };
+    };
+
+    appendFreehandEventPoint = (event, force = false) => {
+      const point = this.getFreehandPoint(event);
+
+      if (!point) return false;
+
+      const nextTrace = appendFreehandPoint(
+        this.freehandTrace,
+        { ...point.screen, internal: point.internal },
+        FREEHAND_MIN_DISTANCE,
+        force,
+      );
+
+      if (nextTrace === this.freehandTrace) return false;
+      this.freehandTrace = nextTrace;
+      if (!this.freehandDragging) {
+        const first = this.freehandTrace[0];
+        const last = this.freehandTrace[this.freehandTrace.length - 1];
+        const deltaX = last.x - first.x;
+        const deltaY = last.y - first.y;
+
+        this.freehandDragging = deltaX * deltaX + deltaY * deltaY >= FREEHAND_DRAG_THRESHOLD * FREEHAND_DRAG_THRESHOLD;
+      }
+      this.setState(({ freehandPoints }) => ({
+        freehandPoints: [...freehandPoints, point.canvas.x, point.canvas.y],
+      }));
+      return true;
+    };
+
+    attachFreehandFallback = () => {
+      window.addEventListener("pointermove", this.handlePointerMove, true);
+      window.addEventListener("pointerup", this.handlePointerUp, true);
+      window.addEventListener("pointercancel", this.handlePointerCancel, true);
+    };
+
+    detachFreehandFallback = () => {
+      window.removeEventListener("pointermove", this.handlePointerMove, true);
+      window.removeEventListener("pointerup", this.handlePointerUp, true);
+      window.removeEventListener("pointercancel", this.handlePointerCancel, true);
+    };
+
+    resetFreehand = ({ updateState = true } = {}) => {
+      const pointerId = this.freehandPointerId;
+      const captureTarget = this.freehandCaptureTarget;
+
+      this.freehandPointerId = null;
+      this.freehandCaptureTarget = null;
+      this.freehandTool = null;
+      this.freehandTrace = [];
+      this.freehandDragging = false;
+      this.detachFreehandFallback();
+      captureTarget?.removeEventListener?.("lostpointercapture", this.handleLostPointerCapture);
+      if (pointerId !== null && captureTarget?.hasPointerCapture?.(pointerId)) {
+        try {
+          captureTarget.releasePointerCapture(pointerId);
+        } catch {
+          // Synthetic events and capture-less browsers may not own native capture.
+        }
+      }
+
+      if (updateState) this.setState({ freehandPoints: [] });
+    };
+
+    rememberFreehandCompatibilityEvent = (event) => {
+      const clientX = Number.isFinite(event?.clientX) ? event.clientX : event?.offsetX;
+      const clientY = Number.isFinite(event?.clientY) ? event.clientY : event?.offsetY;
+
+      if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return;
+      this.freehandCompatibilityGuard = {
+        clientX,
+        clientY,
+        expiresAt: Date.now() + FREEHAND_COMPATIBILITY_GUARD_MS,
+      };
+    };
+
+    shouldSuppressFreehandCompatibilityEvent = (event) => {
+      if (!isFF(FF_POLYGON_FREEHAND)) return false;
+      if (this.freehandDragging) return true;
+
+      const guard = this.freehandCompatibilityGuard;
+
+      if (!guard || Date.now() > guard.expiresAt) return false;
+
+      const clientX = Number.isFinite(event?.clientX) ? event.clientX : event?.offsetX;
+      const clientY = Number.isFinite(event?.clientY) ? event.clientY : event?.offsetY;
+      const deltaX = clientX - guard.clientX;
+      const deltaY = clientY - guard.clientY;
+
+      return (
+        Number.isFinite(deltaX) &&
+        Number.isFinite(deltaY) &&
+        deltaX * deltaX + deltaY * deltaY <=
+          FREEHAND_COMPATIBILITY_GUARD_DISTANCE * FREEHAND_COMPATIBILITY_GUARD_DISTANCE
+      );
+    };
+
+    handlePointerDown = (eventLike) => {
+      const event = eventLike.evt || eventLike;
+
+      if (this.freehandPointerId !== null || event.isPrimary === false || (event.button ?? 0) !== 0) return;
+
+      const tool = this.getFreehandTool();
+
+      if (!tool?.canStartFreehand()) return;
+
+      const point = this.getFreehandPoint(event);
+
+      if (!point) return;
+
+      this.freehandCompatibilityGuard = null;
+      this.freehandPointerId = event.pointerId;
+      this.freehandTool = tool;
+      this.freehandTrace = appendFreehandPoint([], { ...point.screen, internal: point.internal });
+      this.setState({ freehandPoints: [point.canvas.x, point.canvas.y] });
+
+      const captureTarget = this.props.item.stageRef?.content;
+
+      this.freehandCaptureTarget = captureTarget ?? null;
+      captureTarget?.addEventListener?.("lostpointercapture", this.handleLostPointerCapture);
+      try {
+        captureTarget?.setPointerCapture?.(event.pointerId);
+      } catch {
+        // Continue with window listeners when pointer capture is unavailable.
+      }
+
+      if (!captureTarget?.hasPointerCapture?.(event.pointerId)) this.attachFreehandFallback();
+    };
+
+    handlePointerMove = (eventLike) => {
+      const event = eventLike.evt || eventLike;
+
+      if (event.pointerId !== this.freehandPointerId) return;
+
+      const coalescedSamples = event.getCoalescedEvents?.();
+      const samples = coalescedSamples?.length ? coalescedSamples : [event];
+
+      for (const sample of samples) this.appendFreehandEventPoint(sample);
+      if (this.freehandDragging) event.preventDefault?.();
+    };
+
+    handlePointerUp = (eventLike) => {
+      const event = eventLike.evt || eventLike;
+
+      if (event.pointerId !== this.freehandPointerId) return;
+
+      this.appendFreehandEventPoint(event, true);
+      const wasDragging = this.freehandDragging;
+
+      if (wasDragging) {
+        event.preventDefault?.();
+        this.rememberFreehandCompatibilityEvent(event);
+        const points = simplifyFreehandPoints(this.freehandTrace, FREEHAND_SIMPLIFY_EPSILON).map(
+          ({ internal }) => internal,
+        );
+
+        if (points.length >= 3 && this.freehandTool === this.getFreehandTool() && isAlive(this.freehandTool)) {
+          this.freehandTool.commitFreehand(points);
+        }
+      }
+
+      this.resetFreehand();
+    };
+
+    handlePointerCancel = (eventLike) => {
+      const event = eventLike.evt || eventLike;
+
+      if (event.pointerId !== this.freehandPointerId) return;
+      if (this.freehandDragging) this.rememberFreehandCompatibilityEvent(event);
+      this.resetFreehand();
+    };
+
+    handleLostPointerCapture = (event) => {
+      if (event.pointerId === this.freehandPointerId) this.resetFreehand();
+    };
+
     handleOnClick = (e) => {
       const { item } = this.props;
+      const evt = e.evt || e;
+
+      if (this.shouldSuppressFreehandCompatibilityEvent(evt)) return;
 
       if (isFF(FF_DEV_1442)) {
         this.handleDeferredMouseDown?.(true);
@@ -546,7 +766,6 @@ export default observer(
         return;
       }
 
-      const evt = e.evt || e;
       const { offsetX: x, offsetY: y } = evt;
 
       if (isFF(FF_LSDV_4930)) {
@@ -617,6 +836,7 @@ export default observer(
     };
 
     handleMouseDown = (e) => {
+      if (this.shouldSuppressFreehandCompatibilityEvent(e.evt || e)) return true;
       this.mouseDown = true;
       const { item } = this.props;
       const isPanTool = item.getToolsManager().findSelectedTool()?.fullName === "ZoomPanTool";
@@ -753,6 +973,7 @@ export default observer(
      */
     handleMouseUp = (e) => {
       this.mouseDown = false;
+      if (this.shouldSuppressFreehandCompatibilityEvent(e.evt || e)) return;
       const { item } = this.props;
 
       if (isFF(FF_DEV_1442)) {
@@ -775,6 +996,7 @@ export default observer(
     };
 
     handleMouseMove = (e) => {
+      if (this.shouldSuppressFreehandCompatibilityEvent(e.evt || e)) return;
       const { item } = this.props;
 
       item.freezeHistory();
@@ -984,6 +1206,7 @@ export default observer(
     };
 
     componentWillUnmount() {
+      this.resetFreehand({ updateState: false });
       this.detachObserver();
       window.removeEventListener("resize", this.onResize);
       window.removeEventListener("mousemove", this.handleGlobalMouseMove);
@@ -1152,6 +1375,10 @@ export default observer(
                 onMouseDown={this.handleMouseDown}
                 onMouseMove={this.handleMouseMove}
                 onMouseUp={this.handleMouseUp}
+                onPointerDown={this.handlePointerDown}
+                onPointerMove={this.handlePointerMove}
+                onPointerUp={this.handlePointerUp}
+                onPointerCancel={this.handlePointerCancel}
                 onWheel={item.zoom ? this.handleZoom : () => {}}
               />
             ) : null}
@@ -1191,6 +1418,10 @@ const EntireStage = observer(
     onMouseDown,
     onMouseMove,
     onMouseUp,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
     onWheel,
     crosshairRef,
   }) => {
@@ -1220,7 +1451,13 @@ const EntireStage = observer(
         ref={(ref) => {
           item.setStageRef(ref);
         }}
-        className={[styles["image-element"], ...imagePositionClassnames].join(" ")}
+        className={[
+          styles["image-element"],
+          ...imagePositionClassnames,
+          isFF(FF_POLYGON_FREEHAND) ? styles["freehand-enabled"] : null,
+        ]
+          .filter(Boolean)
+          .join(" ")}
         width={size.width}
         height={size.height}
         scaleX={item.zoomScale}
@@ -1237,6 +1474,10 @@ const EntireStage = observer(
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUp}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
         onWheel={onWheel}
       >
         <StageContent item={item} store={store} state={state} crosshairRef={crosshairRef} />
@@ -1440,6 +1681,19 @@ const StageContent = observer(({ item, store, state, crosshairRef }) => {
           <Fragment key={groupName} />
         );
       })}
+      {state.freehandPoints.length >= 4 && (
+        <Layer name="freehand-preview" listening={false}>
+          <Line
+            points={state.freehandPoints}
+            stroke="#1890ff"
+            strokeWidth={2}
+            strokeScaleEnabled={false}
+            lineCap="round"
+            lineJoin="round"
+            listening={false}
+          />
+        </Layer>
+      )}
       <Selection item={item} isPanning={state.isPanning} />
       <DrawingRegion item={item} />
       {item.smoothingEnabled === false && <PixelGridLayer item={item} />}

--- a/web/libs/editor/src/components/ImageView/ImageView.jsx
+++ b/web/libs/editor/src/components/ImageView/ImageView.jsx
@@ -26,7 +26,11 @@ import { Image } from "./Image";
 import {
   appendFreehandPoint,
   FREEHAND_MIN_DISTANCE,
+  FREEHAND_REPAIR_MIN_RAW_POINTS,
+  FREEHAND_REPAIR_SNAP_RADIUS,
   FREEHAND_SIMPLIFY_EPSILON,
+  buildFreehandRepairContour,
+  isValidFreehandContour,
   simplifyFreehandPoints,
 } from "../../utils/freehand";
 
@@ -37,6 +41,18 @@ const imgDefaultProps = { crossOrigin: "anonymous" };
 const FREEHAND_COMPATIBILITY_GUARD_MS = 1500;
 const FREEHAND_COMPATIBILITY_GUARD_DISTANCE = 25;
 const FREEHAND_DRAG_THRESHOLD = 5;
+
+const projectPointToEdge = (point, start, end) => {
+  const deltaX = end.x - start.x;
+  const deltaY = end.y - start.y;
+  const lengthSquared = deltaX * deltaX + deltaY * deltaY;
+
+  if (!Number.isFinite(lengthSquared) || lengthSquared === 0) return null;
+  const projection = ((point.x - start.x) * deltaX + (point.y - start.y) * deltaY) / lengthSquared;
+  const ratio = Math.max(0, Math.min(1, projection));
+
+  return { x: start.x + ratio * deltaX, y: start.y + ratio * deltaY };
+};
 
 export const splitRegions = (regions) => {
   const brushRegions = [];
@@ -540,8 +556,13 @@ export default observer(
     freehandPointerId = null;
     freehandCaptureTarget = null;
     freehandTool = null;
+    freehandMode = null;
     freehandTrace = [];
     freehandDragging = false;
+    pendingFreehandMouseDown = null;
+    freehandRepairRegion = null;
+    freehandRepairEdgeIndex = null;
+    freehandRepairDragState = null;
     freehandCompatibilityGuard = null;
     freehandCompatibilityClock = Date.now;
 
@@ -557,6 +578,77 @@ export default observer(
       const tool = this.props.item.getToolsManager().findSelectedTool();
 
       return tool?.toolName === "PolygonTool" && tool.canStartFreehand && tool.commitFreehand ? tool : null;
+    };
+
+    getFreehandRepairTarget = (target, tool, event) => {
+      if (event?.metaKey || event?.ctrlKey || event?.altKey || event?.shiftKey) return null;
+
+      const { item } = this.props;
+      const selectedRegions = Array.from(item.selectedRegions ?? item.annotation?.selectedRegions ?? []);
+
+      if (selectedRegions.length !== 1) return null;
+      const region = selectedRegions[0];
+
+      if (tool?.canRepairFreehand?.(region) !== true) return null;
+
+      let node = target;
+      let edgeIndex = null;
+      let belongsToRegion = false;
+
+      while (node) {
+        const name = typeof node.name === "function" ? node.name() : (node.attrs?.name ?? node.name);
+        const edgeMatch = typeof name === "string" ? /^border_(\d+)_\d+$/.exec(name) : null;
+
+        if (edgeMatch) edgeIndex = Number(edgeMatch[1]);
+        if (node === region.shapeRef || String(name) === String(region.id)) {
+          belongsToRegion = true;
+          break;
+        }
+        node = node.getParent?.() ?? node.parent ?? null;
+      }
+
+      return belongsToRegion && Number.isInteger(edgeIndex) ? { region, edgeIndex } : null;
+    };
+
+    getFreehandRepairContour = (region) =>
+      Array.from(region?.points ?? [], (point) => ({ x: point.canvasX, y: point.canvasY })).filter(
+        ({ x, y }) => Number.isFinite(x) && Number.isFinite(y),
+      );
+
+    suspendFreehandRepairDragging = (region) => {
+      const node = region?.shapeRef;
+
+      if (!node?.draggable) return;
+      this.freehandRepairDragState = { node, draggable: node.draggable() };
+      node.stopDrag?.();
+      node.draggable(false);
+    };
+
+    restoreFreehandRepairDragging = () => {
+      const dragState = this.freehandRepairDragState;
+
+      this.freehandRepairDragState = null;
+      if (dragState?.node?.draggable) dragState.node.draggable(dragState.draggable);
+    };
+
+    insertFreehandRepairPoint = (event) => {
+      const region = this.freehandRepairRegion;
+      const edgeIndex = this.freehandRepairEdgeIndex;
+
+      if (!region || !Number.isInteger(edgeIndex) || !region.insertPoint) return false;
+      if (this.freehandTool?.canRepairFreehand?.(region) !== true) return false;
+
+      const point = this.getFreehandPoint(event);
+      const contour = this.getFreehandRepairContour(region);
+      const start = contour[edgeIndex];
+      const end = contour[(edgeIndex + 1) % contour.length];
+
+      if (!point || !start || !end) return false;
+
+      const anchor = projectPointToEdge(point.canvas, start, end);
+
+      if (!anchor) return false;
+      return Boolean(region.insertPoint(edgeIndex + 1, anchor.x, anchor.y));
     };
 
     isRightElementToCatchToolInteractions = (element, isMoveTool) => {
@@ -599,10 +691,17 @@ export default observer(
 
       if (!screen || !Number.isFinite(screen.x) || !Number.isFinite(screen.y)) return null;
 
-      const [canvasX, canvasY] = item.fixZoomedCoords([screen.x, screen.y]);
+      const [rawCanvasX, rawCanvasY] = item.fixZoomedCoords([screen.x, screen.y]);
+      const maxCanvasX = item.stageWidth;
+      const maxCanvasY = item.stageHeight;
+      const canvasX = Number.isFinite(maxCanvasX) ? Math.max(0, Math.min(maxCanvasX, rawCanvasX)) : rawCanvasX;
+      const canvasY = Number.isFinite(maxCanvasY) ? Math.max(0, Math.min(maxCanvasY, rawCanvasY)) : rawCanvasY;
+      const clampedScreen = item.zoomOriginalCoords?.([canvasX, canvasY]);
+      const screenX = Number.isFinite(clampedScreen?.[0]) ? clampedScreen[0] : screen.x;
+      const screenY = Number.isFinite(clampedScreen?.[1]) ? clampedScreen[1] : screen.y;
 
       return {
-        screen,
+        screen: { x: screenX, y: screenY },
         canvas: { x: canvasX, y: canvasY },
         internal: [item.canvasToInternalX(canvasX), item.canvasToInternalY(canvasY)],
       };
@@ -615,7 +714,7 @@ export default observer(
 
       const nextTrace = appendFreehandPoint(
         this.freehandTrace,
-        { ...point.screen, internal: point.internal },
+        { ...point.screen, canvas: point.canvas, internal: point.internal },
         FREEHAND_MIN_DISTANCE,
         force,
       );
@@ -629,6 +728,7 @@ export default observer(
         const deltaY = last.y - first.y;
 
         this.freehandDragging = deltaX * deltaX + deltaY * deltaY >= FREEHAND_DRAG_THRESHOLD * FREEHAND_DRAG_THRESHOLD;
+        if (this.freehandDragging) this.cancelDeferredFreehandCompatibility();
       }
       this.setState(({ freehandPoints }) => ({
         freehandPoints: [...freehandPoints, point.canvas.x, point.canvas.y],
@@ -652,11 +752,16 @@ export default observer(
       const pointerId = this.freehandPointerId;
       const captureTarget = this.freehandCaptureTarget;
 
+      this.restoreFreehandRepairDragging();
       this.freehandPointerId = null;
       this.freehandCaptureTarget = null;
       this.freehandTool = null;
+      this.freehandMode = null;
       this.freehandTrace = [];
       this.freehandDragging = false;
+      this.pendingFreehandMouseDown = null;
+      this.freehandRepairRegion = null;
+      this.freehandRepairEdgeIndex = null;
       this.detachFreehandFallback();
       captureTarget?.removeEventListener?.("lostpointercapture", this.handleLostPointerCapture);
       if (pointerId !== null && captureTarget?.hasPointerCapture?.(pointerId)) {
@@ -671,20 +776,36 @@ export default observer(
     };
 
     rememberFreehandCompatibilityEvent = (event) => {
+      this.cancelDeferredFreehandCompatibility();
       const clientX = Number.isFinite(event?.clientX) ? event.clientX : event?.offsetX;
       const clientY = Number.isFinite(event?.clientY) ? event.clientY : event?.offsetY;
 
       if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return;
-      this.freehandCompatibilityGuard = {
+      const guard = {
         clientX,
         clientY,
         expiresAt: this.freehandCompatibilityClock() + FREEHAND_COMPATIBILITY_GUARD_MS,
       };
+
+      this.freehandCompatibilityGuard = guard;
+      if (this.freehandMode === "repair") {
+        this.freehandRepairRegion?.suppressNextEdgeClick?.({
+          ...guard,
+          radius: FREEHAND_COMPATIBILITY_GUARD_DISTANCE,
+        });
+      }
     };
 
     shouldSuppressFreehandCompatibilityEvent = (event) => {
       if (!isFF(FF_POLYGON_FREEHAND)) return false;
-      if (this.freehandDragging) return true;
+      if (this.freehandPointerId !== null) {
+        if (this.freehandDragging) this.cancelDeferredFreehandCompatibility();
+        return true;
+      }
+      if (this.freehandDragging) {
+        this.cancelDeferredFreehandCompatibility();
+        return true;
+      }
 
       const guard = this.freehandCompatibilityGuard;
 
@@ -699,12 +820,14 @@ export default observer(
       const deltaX = clientX - guard.clientX;
       const deltaY = clientY - guard.clientY;
 
-      return (
+      const shouldSuppress =
         Number.isFinite(deltaX) &&
         Number.isFinite(deltaY) &&
         deltaX * deltaX + deltaY * deltaY <=
-          FREEHAND_COMPATIBILITY_GUARD_DISTANCE * FREEHAND_COMPATIBILITY_GUARD_DISTANCE
-      );
+          FREEHAND_COMPATIBILITY_GUARD_DISTANCE * FREEHAND_COMPATIBILITY_GUARD_DISTANCE;
+
+      if (shouldSuppress) this.cancelDeferredFreehandCompatibility();
+      return shouldSuppress;
     };
 
     handlePointerDown = (eventLike) => {
@@ -713,25 +836,52 @@ export default observer(
       if (this.freehandPointerId !== null || event.isPrimary === false || (event.button ?? 0) !== 0) return;
 
       const tool = this.getFreehandTool();
+      const repairTarget = this.getFreehandRepairTarget(eventLike.target, tool, event);
 
-      if (!tool?.canStartFreehand()) return;
+      if (!repairTarget && !tool?.canStartFreehand()) return;
 
       const { item } = this.props;
 
       item.updateSkipInteractions(eventLike);
       if (item.annotation.isReadOnly()) return;
       if (eventLike.target?.getParent?.()?.className === "Transformer") return;
-      if (!this.isToolInteractionTarget(eventLike.target)) return;
+      if (!repairTarget && !this.isToolInteractionTarget(eventLike.target)) return;
 
       const point = this.getFreehandPoint(event);
 
       if (!point) return;
 
+      let initialCanvasPoint = point.canvas;
+
+      if (repairTarget) {
+        const contour = this.getFreehandRepairContour(repairTarget.region);
+        const edgeStart = contour[repairTarget.edgeIndex];
+        const edgeEnd = contour[(repairTarget.edgeIndex + 1) % contour.length];
+        const anchor = edgeStart && edgeEnd ? projectPointToEdge(point.canvas, edgeStart, edgeEnd) : null;
+        const zoom = Number.isFinite(item.zoomScale) && item.zoomScale > 0 ? item.zoomScale : 1;
+        const anchorDistanceSquared = anchor
+          ? (anchor.x - point.canvas.x) ** 2 + (anchor.y - point.canvas.y) ** 2
+          : Number.POSITIVE_INFINITY;
+
+        if (!anchor || anchorDistanceSquared > (FREEHAND_REPAIR_SNAP_RADIUS / zoom) ** 2) return;
+        initialCanvasPoint = anchor;
+        event.preventDefault?.();
+        eventLike.cancelBubble = true;
+      }
+
       this.freehandCompatibilityGuard = null;
       this.freehandPointerId = event.pointerId;
       this.freehandTool = tool;
-      this.freehandTrace = appendFreehandPoint([], { ...point.screen, internal: point.internal });
-      this.setState({ freehandPoints: [point.canvas.x, point.canvas.y] });
+      this.freehandMode = repairTarget ? "repair" : "create";
+      this.freehandRepairRegion = repairTarget?.region ?? null;
+      this.freehandRepairEdgeIndex = repairTarget?.edgeIndex ?? null;
+      this.freehandTrace = appendFreehandPoint([], {
+        ...point.screen,
+        canvas: initialCanvasPoint,
+        internal: point.internal,
+      });
+      this.setState({ freehandPoints: [initialCanvasPoint.x, initialCanvasPoint.y] });
+      if (repairTarget) this.suspendFreehandRepairDragging(repairTarget.region);
 
       const captureTarget = this.props.item.stageRef?.content;
 
@@ -763,34 +913,73 @@ export default observer(
 
       if (event.pointerId !== this.freehandPointerId) return;
 
-      this.appendFreehandEventPoint(event, true);
-      const wasDragging = this.freehandDragging;
+      let replayMouseDown = null;
 
-      if (wasDragging) {
-        event.preventDefault?.();
-        this.rememberFreehandCompatibilityEvent(event);
-        const points = simplifyFreehandPoints(this.freehandTrace, FREEHAND_SIMPLIFY_EPSILON).map(
-          ({ internal }) => internal,
-        );
+      try {
+        this.appendFreehandEventPoint(event, true);
+        const wasDragging = this.freehandDragging;
+        const mode = this.freehandMode;
 
-        if (points.length >= 3 && this.freehandTool === this.getFreehandTool() && isAlive(this.freehandTool)) {
-          this.freehandTool.commitFreehand(points);
+        if (wasDragging) {
+          event.preventDefault?.();
+          this.rememberFreehandCompatibilityEvent(event);
+          const simplifiedTrace = simplifyFreehandPoints(this.freehandTrace, FREEHAND_SIMPLIFY_EPSILON);
+          const toolIsCurrent = this.freehandTool === this.getFreehandTool() && isAlive(this.freehandTool);
+
+          if (mode === "repair") {
+            const { item } = this.props;
+            const region = this.freehandRepairRegion;
+            const zoom = Number.isFinite(item.zoomScale) && item.zoomScale > 0 ? item.zoomScale : 1;
+            const repair =
+              this.freehandTrace.length >= FREEHAND_REPAIR_MIN_RAW_POINTS &&
+              simplifiedTrace.length >= 2 &&
+              toolIsCurrent &&
+              this.freehandTool.canRepairFreehand?.(region) === true
+                ? buildFreehandRepairContour(
+                    this.getFreehandRepairContour(region),
+                    simplifiedTrace.map(({ canvas }) => canvas),
+                    { snapRadius: FREEHAND_REPAIR_SNAP_RADIUS / zoom },
+                  )
+                : null;
+
+            if (repair) {
+              const points = repair.points.map(({ x, y }) => [item.canvasToInternalX(x), item.canvasToInternalY(y)]);
+
+              this.freehandTool.commitFreehandRepair?.(region, points);
+            }
+          } else {
+            const points = simplifiedTrace.map(({ internal }) => internal);
+
+            if (points.length >= 3 && toolIsCurrent && isValidFreehandContour(points)) {
+              this.freehandTool.commitFreehand(points);
+            }
+          }
+        } else if (mode === "repair") {
+          event.preventDefault?.();
+          this.rememberFreehandCompatibilityEvent(event);
+          this.insertFreehandRepairPoint(event);
+        } else if (mode === "create") {
+          replayMouseDown = this.pendingFreehandMouseDown;
+          this.pendingFreehandMouseDown = null;
         }
+      } finally {
+        this.resetFreehand();
+        if (replayMouseDown) this.handleMouseDown(replayMouseDown);
       }
-
-      this.resetFreehand();
     };
 
     handlePointerCancel = (eventLike) => {
       const event = eventLike.evt || eventLike;
 
       if (event.pointerId !== this.freehandPointerId) return;
-      if (this.freehandDragging) this.rememberFreehandCompatibilityEvent(event);
+      if (this.freehandDragging || this.freehandMode === "repair") this.rememberFreehandCompatibilityEvent(event);
       this.resetFreehand();
     };
 
     handleLostPointerCapture = (event) => {
-      if (event.pointerId === this.freehandPointerId) this.resetFreehand();
+      if (event.pointerId !== this.freehandPointerId) return;
+      if (this.freehandDragging || this.freehandMode === "repair") this.rememberFreehandCompatibilityEvent(event);
+      this.resetFreehand();
     };
 
     handleOnClick = (e) => {
@@ -856,6 +1045,12 @@ export default observer(
       }
     };
 
+    cancelDeferredFreehandCompatibility = () => {
+      this.resetDeferredClickTimeout();
+      this.handleDeferredMouseDown = null;
+      this.pendingFreehandMouseDown = null;
+    };
+
     handleDeferredClick = (handleDeferredMouseDownCallback, handleDeselection, eligibleToDeselect = false) => {
       this.handleDeferredMouseDown = (wasClicked) => {
         if (wasClicked && eligibleToDeselect) {
@@ -877,6 +1072,10 @@ export default observer(
     };
 
     handleMouseDown = (e) => {
+      if (isFF(FF_POLYGON_FREEHAND) && this.freehandPointerId !== null) {
+        if (this.freehandMode === "create" && !this.freehandDragging) this.pendingFreehandMouseDown = e;
+        return true;
+      }
       if (this.shouldSuppressFreehandCompatibilityEvent(e.evt || e)) return true;
       this.mouseDown = true;
       const { item } = this.props;
@@ -1230,6 +1429,13 @@ export default observer(
     }
 
     componentDidUpdate() {
+      if (this.freehandPointerId !== null) {
+        const tool = this.getFreehandTool();
+        const repairIsInvalid =
+          this.freehandMode === "repair" && tool?.canRepairFreehand?.(this.freehandRepairRegion) !== true;
+
+        if (tool !== this.freehandTool || !isAlive(this.freehandTool) || repairIsInvalid) this.resetFreehand();
+      }
       this.onResize();
       this.updateReadyStatus();
     }

--- a/web/libs/editor/src/components/ImageView/ImageView.module.css
+++ b/web/libs/editor/src/components/ImageView/ImageView.module.css
@@ -52,6 +52,10 @@
   position: absolute;
 }
 
+.freehand-enabled {
+  touch-action: none;
+}
+
 .image_position {
   position: absolute;
 

--- a/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
+++ b/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
@@ -283,6 +283,19 @@ function createFreehandRepairHarness() {
   const borders = { attrs: { name: "borders" }, getParent: () => shapeRef };
   const edge = { attrs: { name: "border_0_1" }, getParent: () => borders };
   const edgeTarget = { getParent: () => edge };
+  const fillTarget = { attrs: { name: "_transformable" }, getParent: () => shapeRef };
+  const anchors = { attrs: { name: "anchors" }, getParent: () => shapeRef };
+  let anchorDraggable = true;
+  const anchorTarget = {
+    attrs: { name: "anchor_4_0" },
+    getParent: () => anchors,
+    draggable: jest.fn(function (...args) {
+      if (args.length === 0) return anchorDraggable;
+      anchorDraggable = args[0];
+      return this;
+    }),
+    stopDrag: jest.fn(),
+  };
   const region = {
     id: "repair-region",
     type: "polygonregion",
@@ -305,7 +318,7 @@ function createFreehandRepairHarness() {
     (candidate) => candidate === region && harness.item.selectedRegions.length === 1,
   );
 
-  return { ...harness, edgeTarget, region, shapeRef };
+  return { ...harness, anchorTarget, edgeTarget, fillTarget, region, shapeRef };
 }
 
 describe("splitRegions", () => {
@@ -1597,9 +1610,10 @@ describe("ImageView with feature flags", () => {
     expect(view().freehandPointerId).toBeNull();
   });
 
-  it("repairs the contour when a drag starts on the selected polygon edge", () => {
+  it("repairs the selected contour when a dense anchor wins the hit test", () => {
     const { isFF } = require("../../../utils/feature-flags");
-    const { commitFreehand, commitFreehandRepair, edgeTarget, region, shapeRef, view } = createFreehandRepairHarness();
+    const { anchorTarget, commitFreehand, commitFreehandRepair, region, shapeRef, view } =
+      createFreehandRepairHarness();
     const preventPointerDown = jest.fn();
     const repairTrace = [
       [35, 6],
@@ -1614,7 +1628,7 @@ describe("ImageView with feature flags", () => {
     isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
     act(() => {
       view().handlePointerDown({
-        target: edgeTarget,
+        target: anchorTarget,
         pointerId: 1,
         isPrimary: true,
         button: 0,
@@ -1642,6 +1656,9 @@ describe("ImageView with feature flags", () => {
     expect(shapeRef.stopDrag).toHaveBeenCalledTimes(1);
     expect(shapeRef.draggable).toHaveBeenCalledWith(false);
     expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
+    expect(anchorTarget.stopDrag).toHaveBeenCalledTimes(1);
+    expect(anchorTarget.draggable).toHaveBeenCalledWith(false);
+    expect(anchorTarget.draggable).toHaveBeenLastCalledWith(true);
     expect(view().freehandPointerId).toBeNull();
   });
 
@@ -1710,7 +1727,7 @@ describe("ImageView with feature flags", () => {
     expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
   });
 
-  it("anchors repair to the hit-tested edge when another edge is closer", () => {
+  it("keeps the raw repair start point for release-time contour snapping", () => {
     const { isFF } = require("../../../utils/feature-flags");
     const { edgeTarget, region, view } = createFreehandRepairHarness();
 
@@ -1733,21 +1750,18 @@ describe("ImageView with feature flags", () => {
       });
     });
 
-    expect(view().freehandTrace[0].canvas).toEqual({ x: 30, y: 10 });
+    expect(view().freehandTrace[0].canvas).toEqual({ x: 30, y: 11.5 });
     act(() => view().handlePointerCancel({ pointerId: 1, clientX: 30, clientY: 11.5 }));
   });
 
-  it("does not repair from polygon fill, anchors, or transformer handles", () => {
+  it("starts repair near the contour from polygon fill and anchors, but not elsewhere", () => {
     const { isFF } = require("../../../utils/feature-flags");
-    const { commitFreehandRepair, region, shapeRef, view } = createFreehandRepairHarness();
-    const fill = { attrs: { name: "_transformable" }, getParent: () => shapeRef };
-    const anchors = { attrs: { name: "anchors" }, getParent: () => shapeRef };
-    const anchor = { attrs: { name: "anchor_4_0" }, getParent: () => anchors };
+    const { anchorTarget, commitFreehandRepair, fillTarget, region, view } = createFreehandRepairHarness();
     const transformer = { className: "Transformer", getParent: () => null };
     const transformerHandle = { getParent: () => transformer };
 
     isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
-    [fill, anchor, transformerHandle].forEach((target, index) => {
+    [fillTarget, anchorTarget].forEach((target, index) => {
       act(() => {
         view().handlePointerDown({
           target,
@@ -1758,11 +1772,33 @@ describe("ImageView with feature flags", () => {
           clientY: 10,
         });
       });
-      expect(view().freehandPointerId).toBeNull();
+      expect(view().freehandMode).toBe("repair");
+      expect(view().freehandRepairRegion).toBe(region);
+      act(() => view().handlePointerCancel({ pointerId: index + 1, clientX: 30, clientY: 10 }));
+    });
+
+    act(() => {
+      view().handlePointerDown({
+        target: fillTarget,
+        pointerId: 3,
+        isPrimary: true,
+        button: 0,
+        clientX: 50,
+        clientY: 50,
+      });
+      view().handlePointerDown({
+        target: transformerHandle,
+        pointerId: 4,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 10,
+      });
     });
 
     expect(region.insertPoint).not.toHaveBeenCalled();
     expect(commitFreehandRepair).not.toHaveBeenCalled();
+    expect(view().freehandPointerId).toBeNull();
   });
 
   it("cancels contour repair and restores dragging on pointer cancellation", () => {

--- a/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
+++ b/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
@@ -2,13 +2,14 @@
  * Unit tests for ImageView (components/ImageView/ImageView.jsx)
  */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import ImageView, { splitRegions } from "../ImageView";
 
 jest.mock("../../../utils/feature-flags", () => ({
   isFF: jest.fn(() => false),
   FF_DEV_1442: "fflag_dev_1442",
   FF_LSDV_4930: "fflag_lsdv_4930",
+  FF_POLYGON_FREEHAND: "fflag_feat_front_polygon_freehand",
   FF_ZOOM_OPTIM: "fflag_zoom_optim",
 }));
 
@@ -204,6 +205,56 @@ function createStore(overrides = {}) {
     settings: { setSmoothing: jest.fn(), enableSmoothing: true, fullscreen: true },
     annotationStore: { viewingAll: false, addErrors: jest.fn() },
     ...overrides,
+  };
+}
+
+function createFreehandPointerHarness() {
+  const store = createStore();
+  const commitFreehand = jest.fn();
+  const tool = {
+    toolName: "PolygonTool",
+    canStartFreehand: jest.fn(() => true),
+    commitFreehand,
+  };
+  let pointerPosition = { x: 10, y: 10 };
+  let transformOffset = 0;
+  const captureTarget = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    setPointerCapture: jest.fn(),
+    hasPointerCapture: jest.fn(() => true),
+    releasePointerCapture: jest.fn(),
+  };
+  const stageRef = {
+    content: captureTarget,
+    getPointerPosition: () => pointerPosition,
+    setPointersPositions: (event) => {
+      pointerPosition = { x: event.clientX, y: event.clientY };
+    },
+    on: jest.fn(),
+    off: jest.fn(),
+    getStage: () => null,
+    position: () => ({ x: 0, y: 0 }),
+    scale: () => ({ x: 1, y: 1 }),
+  };
+  const item = createItem({
+    stageRef,
+    getToolsManager: () => ({ findSelectedTool: () => tool, allTools: () => [tool] }),
+    fixZoomedCoords: ([x, y]) => [x + transformOffset, y + transformOffset],
+    canvasToInternalX: (x) => x,
+    canvasToInternalY: (y) => y,
+  });
+  item.store = store;
+  let viewRef;
+
+  render(<ImageView ref={(ref) => (viewRef = ref)} item={item} store={store} />);
+  return {
+    commitFreehand,
+    item,
+    setTransformOffset: (offset) => {
+      transformOffset = offset;
+    },
+    view: () => viewRef,
   };
 }
 
@@ -1221,5 +1272,71 @@ describe("ImageView with feature flags", () => {
     jest.advanceTimersByTime(150);
     expect(item.event).toHaveBeenCalledWith("mousedown", expect.anything(), 20, 30);
     jest.useRealTimers();
+  });
+
+  it("creates points from a pointer drag only when freehand drawing is enabled", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, view } = createFreehandPointerHarness();
+    const drag = () => {
+      act(() => {
+        view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+        view().handlePointerMove({
+          pointerId: 1,
+          clientX: 40,
+          clientY: 10,
+          getCoalescedEvents: () => [],
+          preventDefault: jest.fn(),
+        });
+        view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+        view().handlePointerUp({ pointerId: 1, clientX: 10, clientY: 40, preventDefault: jest.fn() });
+      });
+    };
+
+    isFF.mockReturnValue(false);
+    drag();
+    expect(commitFreehand).not.toHaveBeenCalled();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    drag();
+    expect(commitFreehand).toHaveBeenCalledTimes(1);
+    expect(commitFreehand.mock.calls[0][0]).toHaveLength(4);
+  });
+
+  it("keeps each sample in the coordinate transform active when it was collected", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, setTransformOffset, view } = createFreehandPointerHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 10, preventDefault: jest.fn() });
+      setTransformOffset(100);
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 10, clientY: 40, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).toHaveBeenCalledWith([
+      [10, 10],
+      [40, 10],
+      [140, 140],
+      [110, 140],
+    ]);
+  });
+
+  it("lets a below-threshold pointer gesture continue through the stock click path", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, item, view } = createFreehandPointerHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+      view().handlePointerMove({ pointerId: 1, clientX: 13, clientY: 10, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 13, clientY: 10, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).not.toHaveBeenCalled();
+    expect(view().shouldSuppressFreehandCompatibilityEvent({ clientX: 13, clientY: 10 })).toBe(false);
+    view().handleOnClick({ evt: { offsetX: 13, offsetY: 10, clientX: 13, clientY: 10 } });
+    expect(item.event).toHaveBeenCalledWith("click", expect.anything(), 13, 10);
   });
 });

--- a/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
+++ b/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
@@ -251,6 +251,7 @@ function createFreehandPointerHarness() {
   return {
     commitFreehand,
     item,
+    stageRef,
     setTransformOffset: (offset) => {
       transformOffset = offset;
     },
@@ -1276,10 +1277,17 @@ describe("ImageView with feature flags", () => {
 
   it("creates points from a pointer drag only when freehand drawing is enabled", () => {
     const { isFF } = require("../../../utils/feature-flags");
-    const { commitFreehand, view } = createFreehandPointerHarness();
+    const { commitFreehand, stageRef, view } = createFreehandPointerHarness();
     const drag = () => {
       act(() => {
-        view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+        view().handlePointerDown({
+          target: stageRef,
+          pointerId: 1,
+          isPrimary: true,
+          button: 0,
+          clientX: 10,
+          clientY: 10,
+        });
         view().handlePointerMove({
           pointerId: 1,
           clientX: 40,
@@ -1304,11 +1312,18 @@ describe("ImageView with feature flags", () => {
 
   it("keeps each sample in the coordinate transform active when it was collected", () => {
     const { isFF } = require("../../../utils/feature-flags");
-    const { commitFreehand, setTransformOffset, view } = createFreehandPointerHarness();
+    const { commitFreehand, setTransformOffset, stageRef, view } = createFreehandPointerHarness();
 
     isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
     act(() => {
-      view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
       view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 10, preventDefault: jest.fn() });
       setTransformOffset(100);
       view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
@@ -1325,11 +1340,18 @@ describe("ImageView with feature flags", () => {
 
   it("lets a below-threshold pointer gesture continue through the stock click path", () => {
     const { isFF } = require("../../../utils/feature-flags");
-    const { commitFreehand, item, view } = createFreehandPointerHarness();
+    const { commitFreehand, item, stageRef, view } = createFreehandPointerHarness();
 
     isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
     act(() => {
-      view().handlePointerDown({ pointerId: 1, isPrimary: true, button: 0, clientX: 10, clientY: 10 });
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
       view().handlePointerMove({ pointerId: 1, clientX: 13, clientY: 10, preventDefault: jest.fn() });
       view().handlePointerUp({ pointerId: 1, clientX: 13, clientY: 10, preventDefault: jest.fn() });
     });
@@ -1338,5 +1360,112 @@ describe("ImageView with feature flags", () => {
     expect(view().shouldSuppressFreehandCompatibilityEvent({ clientX: 13, clientY: 10 })).toBe(false);
     view().handleOnClick({ evt: { offsetX: 13, offsetY: 10, clientX: 13, clientY: 10 } });
     expect(item.event).toHaveBeenCalledWith("click", expect.anything(), 13, 10);
+  });
+
+  it("does not start freehand drawing from an existing region or transformer", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, view } = createFreehandPointerHarness();
+    const dragFrom = (target, pointerId) => {
+      act(() => {
+        view().handlePointerDown({
+          target,
+          pointerId,
+          isPrimary: true,
+          button: 0,
+          clientX: 10,
+          clientY: 10,
+        });
+        view().handlePointerMove({ pointerId, clientX: 40, clientY: 10, preventDefault: jest.fn() });
+        view().handlePointerMove({ pointerId, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+        view().handlePointerUp({ pointerId, clientX: 10, clientY: 40, preventDefault: jest.fn() });
+      });
+    };
+    const region = { parent: null, getParent: () => null };
+    const transformer = { className: "Transformer" };
+    const anchor = { parent: transformer, getParent: () => transformer };
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    dragFrom(region, 1);
+    dragFrom(anchor, 2);
+
+    expect(commitFreehand).not.toHaveBeenCalled();
+    expect(view().freehandPointerId).toBeNull();
+  });
+
+  it("does not start freehand drawing on a read-only annotation", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, item, stageRef, view } = createFreehandPointerHarness();
+
+    item.annotation.isReadOnly = () => true;
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 10, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).not.toHaveBeenCalled();
+    expect(view().freehandPointerId).toBeNull();
+  });
+
+  it("allows freehand drawing over a region when Cmd/Ctrl interaction skipping is active", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, item, view } = createFreehandPointerHarness();
+    const region = { parent: null, getParent: () => null };
+    let skipInteractions = false;
+
+    item.updateSkipInteractions = jest.fn(({ evt }) => {
+      skipInteractions = evt.metaKey || evt.ctrlKey;
+    });
+    item.getSkipInteractions = () => skipInteractions;
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: region,
+        evt: {
+          pointerId: 1,
+          isPrimary: true,
+          button: 0,
+          clientX: 10,
+          clientY: 10,
+          metaKey: true,
+        },
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 10, preventDefault: jest.fn() });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 10, clientY: 40, preventDefault: jest.fn() });
+    });
+
+    expect(item.updateSkipInteractions).toHaveBeenCalledTimes(1);
+    expect(commitFreehand).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables touch-action suppression only while Polygon is selected", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const store = createStore();
+    const polygonTool = { toolName: "PolygonTool" };
+    const polygonItem = createItem({
+      getToolsManager: () => ({ findSelectedTool: () => polygonTool, allTools: () => [polygonTool] }),
+    });
+    const rectangleTool = { toolName: "RectangleTool" };
+    const rectangleItem = createItem({
+      getToolsManager: () => ({ findSelectedTool: () => rectangleTool, allTools: () => [rectangleTool] }),
+    });
+
+    polygonItem.store = store;
+    rectangleItem.store = store;
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    const { rerender } = render(<ImageView item={polygonItem} store={store} />);
+    expect(screen.getByTestId("konva-stage").className).toContain("freehand-enabled");
+
+    rerender(<ImageView item={rectangleItem} store={store} />);
+    expect(screen.getByTestId("konva-stage").className).not.toContain("freehand-enabled");
   });
 });

--- a/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
+++ b/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
@@ -1362,6 +1362,23 @@ describe("ImageView with feature flags", () => {
     expect(item.event).toHaveBeenCalledWith("click", expect.anything(), 13, 10);
   });
 
+  it("prunes a compatibility guard after its TTL", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { view } = createFreehandPointerHarness();
+    let now = 1000;
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    view().freehandCompatibilityClock = () => now;
+    view().rememberFreehandCompatibilityEvent({ clientX: 10, clientY: 20 });
+
+    expect(view().freehandCompatibilityGuard.expiresAt).toBe(2500);
+    now = 2499;
+    expect(view().shouldSuppressFreehandCompatibilityEvent({ clientX: 10, clientY: 20 })).toBe(true);
+    now = 2501;
+    expect(view().shouldSuppressFreehandCompatibilityEvent({ clientX: 10, clientY: 20 })).toBe(false);
+    expect(view().freehandCompatibilityGuard).toBeNull();
+  });
+
   it("does not start freehand drawing from an existing region or transformer", () => {
     const { isFF } = require("../../../utils/feature-flags");
     const { commitFreehand, view } = createFreehandPointerHarness();

--- a/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
+++ b/web/libs/editor/src/components/ImageView/__tests__/ImageView.test.jsx
@@ -181,6 +181,7 @@ function createItem(overrides = {}) {
     setSkipInteractions: jest.fn(),
     updateSkipInteractions: jest.fn(),
     fixZoomedCoords: (c) => c,
+    zoomOriginalCoords: (c) => c,
     annotation: {
       isReadOnly: () => false,
       selectedRegions: [],
@@ -211,10 +212,13 @@ function createStore(overrides = {}) {
 function createFreehandPointerHarness() {
   const store = createStore();
   const commitFreehand = jest.fn();
+  const commitFreehandRepair = jest.fn();
   const tool = {
     toolName: "PolygonTool",
     canStartFreehand: jest.fn(() => true),
+    canRepairFreehand: jest.fn(() => false),
     commitFreehand,
+    commitFreehandRepair,
   };
   let pointerPosition = { x: 10, y: 10 };
   let transformOffset = 0;
@@ -227,6 +231,7 @@ function createFreehandPointerHarness() {
   };
   const stageRef = {
     content: captureTarget,
+    getParent: () => null,
     getPointerPosition: () => pointerPosition,
     setPointersPositions: (event) => {
       pointerPosition = { x: event.clientX, y: event.clientY };
@@ -241,6 +246,7 @@ function createFreehandPointerHarness() {
     stageRef,
     getToolsManager: () => ({ findSelectedTool: () => tool, allTools: () => [tool] }),
     fixZoomedCoords: ([x, y]) => [x + transformOffset, y + transformOffset],
+    zoomOriginalCoords: ([x, y]) => [x - transformOffset, y - transformOffset],
     canvasToInternalX: (x) => x,
     canvasToInternalY: (y) => y,
   });
@@ -250,13 +256,56 @@ function createFreehandPointerHarness() {
   render(<ImageView ref={(ref) => (viewRef = ref)} item={item} store={store} />);
   return {
     commitFreehand,
+    commitFreehandRepair,
     item,
     stageRef,
     setTransformOffset: (offset) => {
       transformOffset = offset;
     },
+    tool,
     view: () => viewRef,
   };
+}
+
+function createFreehandRepairHarness() {
+  const harness = createFreehandPointerHarness();
+  let draggable = true;
+  const shapeRef = {
+    attrs: { name: "repair-region" },
+    getParent: () => null,
+    draggable: jest.fn(function (...args) {
+      if (args.length === 0) return draggable;
+      draggable = args[0];
+      return this;
+    }),
+    stopDrag: jest.fn(),
+  };
+  const borders = { attrs: { name: "borders" }, getParent: () => shapeRef };
+  const edge = { attrs: { name: "border_0_1" }, getParent: () => borders };
+  const edgeTarget = { getParent: () => edge };
+  const region = {
+    id: "repair-region",
+    type: "polygonregion",
+    closed: true,
+    shapeRef,
+    insertPoint: jest.fn(() => ({})),
+    suppressNextEdgeClick: jest.fn(),
+    points: [
+      { canvasX: 10, canvasY: 10 },
+      { canvasX: 90, canvasY: 10 },
+      { canvasX: 90, canvasY: 90 },
+      { canvasX: 10, canvasY: 90 },
+    ],
+  };
+
+  harness.item.selectedRegions = [region];
+  harness.item.annotation.selectedRegions = [region];
+  harness.tool.canStartFreehand.mockReturnValue(false);
+  harness.tool.canRepairFreehand.mockImplementation(
+    (candidate) => candidate === region && harness.item.selectedRegions.length === 1,
+  );
+
+  return { ...harness, edgeTarget, region, shapeRef };
 }
 
 describe("splitRegions", () => {
@@ -1338,6 +1387,73 @@ describe("ImageView with feature flags", () => {
     ]);
   });
 
+  it("clamps captured freehand samples to the image bounds", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, stageRef, view } = createFreehandPointerHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: -100, preventDefault: jest.fn() });
+      view().handlePointerMove({ pointerId: 1, clientX: 450, clientY: 150, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 10, clientY: 350, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).toHaveBeenCalledTimes(1);
+    expect(commitFreehand.mock.calls[0][0].every(([x, y]) => x >= 0 && x <= 400 && y >= 0 && y <= 300)).toBe(true);
+  });
+
+  it("clamps in unrotated image space for a non-square image rotated 90 degrees", () => {
+    const { item, view } = createFreehandPointerHarness();
+
+    item.rotation = 90;
+    item.canvasSize = { width: 300, height: 400 };
+    item.stageWidth = 400;
+    item.stageHeight = 300;
+    item.canvasToInternalX = (x) => x / 4;
+    item.canvasToInternalY = (y) => y / 3;
+
+    expect(view().getFreehandPoint({ clientX: 350, clientY: 100 })).toMatchObject({
+      canvas: { x: 350, y: 100 },
+      internal: [87.5, 100 / 3],
+    });
+    expect(view().getFreehandPoint({ clientX: 100, clientY: 350 })).toMatchObject({
+      canvas: { x: 100, y: 300 },
+      internal: [25, 100],
+    });
+  });
+
+  it("rejects an outside-and-back creation trace that collapses onto itself at the image boundary", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, stageRef, view } = createFreehandPointerHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 450, clientY: 50, preventDefault: jest.fn() });
+      view().handlePointerMove({ pointerId: 1, clientX: 450, clientY: 350, preventDefault: jest.fn() });
+      view().handlePointerMove({ pointerId: 1, clientX: 50, clientY: 350, preventDefault: jest.fn() });
+      view().handlePointerMove({ pointerId: 1, clientX: 450, clientY: 350, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 90, clientY: 90, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).not.toHaveBeenCalled();
+  });
+
   it("lets a below-threshold pointer gesture continue through the stock click path", () => {
     const { isFF } = require("../../../utils/feature-flags");
     const { commitFreehand, item, stageRef, view } = createFreehandPointerHarness();
@@ -1362,6 +1478,37 @@ describe("ImageView with feature flags", () => {
     expect(item.event).toHaveBeenCalledWith("click", expect.anything(), 13, 10);
   });
 
+  it("replays a deferred compatibility mousedown for a below-threshold create gesture", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, item, stageRef, view } = createFreehandPointerHarness();
+    const compatibilityMouseDown = {
+      target: stageRef,
+      evt: { button: 0, offsetX: 10, offsetY: 10, clientX: 10, clientY: 10 },
+    };
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      view().handleMouseDown(compatibilityMouseDown);
+      view().handlePointerUp({ pointerId: 1, clientX: 13, clientY: 10, preventDefault: jest.fn() });
+      view().handleMouseUp({
+        target: stageRef,
+        evt: { offsetX: 13, offsetY: 10, clientX: 13, clientY: 10 },
+      });
+      view().handleOnClick({ evt: { offsetX: 13, offsetY: 10, clientX: 13, clientY: 10 } });
+    });
+
+    expect(commitFreehand).not.toHaveBeenCalled();
+    expect(item.event.mock.calls.map(([name]) => name)).toEqual(["mousedown", "mouseup", "click"]);
+  });
+
   it("prunes a compatibility guard after its TTL", () => {
     const { isFF } = require("../../../utils/feature-flags");
     const { view } = createFreehandPointerHarness();
@@ -1377,6 +1524,47 @@ describe("ImageView with feature flags", () => {
     now = 2501;
     expect(view().shouldSuppressFreehandCompatibilityEvent({ clientX: 10, clientY: 20 })).toBe(false);
     expect(view().freehandCompatibilityGuard).toBeNull();
+  });
+
+  it("cancels deferred mouse compatibility events when freehand and deferred-click flags are both enabled", () => {
+    jest.useFakeTimers();
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, item, stageRef, view } = createFreehandPointerHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand" || flag === "fflag_dev_1442");
+    item.event.mockClear();
+    act(() => {
+      view().handlePointerDown({
+        target: stageRef,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      view().handleMouseDown({
+        target: stageRef,
+        evt: { button: 0, offsetX: 10, offsetY: 10, clientX: 10, clientY: 10 },
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 10, preventDefault: jest.fn() });
+      view().handleMouseMove({
+        target: stageRef,
+        evt: { buttons: 1, offsetX: 40, offsetY: 10, clientX: 40, clientY: 10 },
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 40, clientY: 40, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 10, clientY: 40, preventDefault: jest.fn() });
+      view().handleMouseUp({
+        target: stageRef,
+        evt: { offsetX: 10, offsetY: 40, clientX: 10, clientY: 40 },
+      });
+      view().handleOnClick({ evt: { offsetX: 10, offsetY: 40, clientX: 10, clientY: 40 } });
+      jest.advanceTimersByTime(150);
+    });
+
+    expect(commitFreehand).toHaveBeenCalledTimes(1);
+    expect(item.event).not.toHaveBeenCalled();
+    expect(view().handleDeferredMouseDown).toBeNull();
+    jest.useRealTimers();
   });
 
   it("does not start freehand drawing from an existing region or transformer", () => {
@@ -1407,6 +1595,231 @@ describe("ImageView with feature flags", () => {
 
     expect(commitFreehand).not.toHaveBeenCalled();
     expect(view().freehandPointerId).toBeNull();
+  });
+
+  it("repairs the contour when a drag starts on the selected polygon edge", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, commitFreehandRepair, edgeTarget, region, shapeRef, view } = createFreehandRepairHarness();
+    const preventPointerDown = jest.fn();
+    const repairTrace = [
+      [35, 6],
+      [40, 3],
+      [45, 1],
+      [50, 0],
+      [55, 1],
+      [60, 3],
+      [65, 6],
+    ];
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 10,
+        preventDefault: preventPointerDown,
+      });
+      repairTrace.forEach(([clientX, clientY]) =>
+        view().handlePointerMove({ pointerId: 1, clientX, clientY, preventDefault: jest.fn() }),
+      );
+      view().handlePointerUp({ pointerId: 1, clientX: 70, clientY: 10, preventDefault: jest.fn() });
+    });
+
+    expect(preventPointerDown).toHaveBeenCalledTimes(1);
+    expect(commitFreehand).not.toHaveBeenCalled();
+    expect(commitFreehandRepair).toHaveBeenCalledTimes(1);
+    expect(commitFreehandRepair).toHaveBeenCalledWith(region, expect.any(Array));
+    expect(commitFreehandRepair.mock.calls[0][1].length).toBeGreaterThanOrEqual(4);
+    expect(region.suppressNextEdgeClick).toHaveBeenCalledWith({
+      clientX: 70,
+      clientY: 10,
+      expiresAt: expect.any(Number),
+      radius: 25,
+    });
+    expect(shapeRef.stopDrag).toHaveBeenCalledTimes(1);
+    expect(shapeRef.draggable).toHaveBeenCalledWith(false);
+    expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
+    expect(view().freehandPointerId).toBeNull();
+  });
+
+  it("restores pointer and dragging state when a contour repair commit throws", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehandRepair, edgeTarget, shapeRef, view } = createFreehandRepairHarness();
+    const error = new Error("repair commit failed");
+    const repairTrace = [
+      [35, 6],
+      [40, 3],
+      [45, 1],
+      [50, 0],
+      [55, 1],
+      [60, 3],
+      [65, 6],
+    ];
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    commitFreehandRepair.mockImplementation(() => {
+      throw error;
+    });
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 10,
+        preventDefault: jest.fn(),
+      });
+      repairTrace.forEach(([clientX, clientY]) =>
+        view().handlePointerMove({ pointerId: 1, clientX, clientY, preventDefault: jest.fn() }),
+      );
+    });
+
+    expect(() =>
+      act(() => view().handlePointerUp({ pointerId: 1, clientX: 70, clientY: 10, preventDefault: jest.fn() })),
+    ).toThrow(error);
+    expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
+    expect(view().freehandPointerId).toBeNull();
+    expect(view().freehandTrace).toEqual([]);
+  });
+
+  it("keeps a short selected-edge gesture as stock point insertion", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehandRepair, edgeTarget, region, shapeRef, view } = createFreehandRepairHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 10,
+        preventDefault: jest.fn(),
+      });
+      view().handlePointerUp({ pointerId: 1, clientX: 32, clientY: 11, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehandRepair).not.toHaveBeenCalled();
+    expect(region.insertPoint).toHaveBeenCalledWith(1, 32, 10);
+    expect(region.suppressNextEdgeClick).toHaveBeenCalledTimes(1);
+    expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
+  });
+
+  it("anchors repair to the hit-tested edge when another edge is closer", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { edgeTarget, region, view } = createFreehandRepairHarness();
+
+    region.points = [
+      { canvasX: 10, canvasY: 10 },
+      { canvasX: 90, canvasY: 10 },
+      { canvasX: 90, canvasY: 12 },
+      { canvasX: 10, canvasY: 12 },
+    ];
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 11.5,
+        preventDefault: jest.fn(),
+      });
+    });
+
+    expect(view().freehandTrace[0].canvas).toEqual({ x: 30, y: 10 });
+    act(() => view().handlePointerCancel({ pointerId: 1, clientX: 30, clientY: 11.5 }));
+  });
+
+  it("does not repair from polygon fill, anchors, or transformer handles", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehandRepair, region, shapeRef, view } = createFreehandRepairHarness();
+    const fill = { attrs: { name: "_transformable" }, getParent: () => shapeRef };
+    const anchors = { attrs: { name: "anchors" }, getParent: () => shapeRef };
+    const anchor = { attrs: { name: "anchor_4_0" }, getParent: () => anchors };
+    const transformer = { className: "Transformer", getParent: () => null };
+    const transformerHandle = { getParent: () => transformer };
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    [fill, anchor, transformerHandle].forEach((target, index) => {
+      act(() => {
+        view().handlePointerDown({
+          target,
+          pointerId: index + 1,
+          isPrimary: true,
+          button: 0,
+          clientX: 30,
+          clientY: 10,
+        });
+      });
+      expect(view().freehandPointerId).toBeNull();
+    });
+
+    expect(region.insertPoint).not.toHaveBeenCalled();
+    expect(commitFreehandRepair).not.toHaveBeenCalled();
+  });
+
+  it("cancels contour repair and restores dragging on pointer cancellation", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehandRepair, edgeTarget, region, shapeRef, view } = createFreehandRepairHarness();
+
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        pointerId: 1,
+        isPrimary: true,
+        button: 0,
+        clientX: 30,
+        clientY: 10,
+        preventDefault: jest.fn(),
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 50, clientY: 0, preventDefault: jest.fn() });
+      view().handlePointerCancel({ pointerId: 1, clientX: 50, clientY: 0 });
+    });
+
+    expect(commitFreehandRepair).not.toHaveBeenCalled();
+    expect(region.insertPoint).not.toHaveBeenCalled();
+    expect(shapeRef.draggable).toHaveBeenLastCalledWith(true);
+    expect(view().freehandRepairRegion).toBeNull();
+    expect(view().freehandPointerId).toBeNull();
+  });
+
+  it("keeps Cmd/Ctrl drawing-over-regions in create mode", () => {
+    const { isFF } = require("../../../utils/feature-flags");
+    const { commitFreehand, commitFreehandRepair, edgeTarget, item, tool, view } = createFreehandRepairHarness();
+    let skipInteractions = false;
+
+    tool.canStartFreehand.mockReturnValue(true);
+    item.updateSkipInteractions = jest.fn(({ evt }) => {
+      skipInteractions = Boolean(evt?.metaKey || evt?.ctrlKey);
+    });
+    item.getSkipInteractions = () => skipInteractions;
+    isFF.mockImplementation((flag) => flag === "fflag_feat_front_polygon_freehand");
+    act(() => {
+      view().handlePointerDown({
+        target: edgeTarget,
+        evt: {
+          pointerId: 1,
+          isPrimary: true,
+          button: 0,
+          clientX: 30,
+          clientY: 10,
+          metaKey: true,
+        },
+      });
+      view().handlePointerMove({ pointerId: 1, clientX: 50, clientY: 0, preventDefault: jest.fn() });
+      view().handlePointerUp({ pointerId: 1, clientX: 70, clientY: 10, preventDefault: jest.fn() });
+    });
+
+    expect(commitFreehand).toHaveBeenCalledTimes(1);
+    expect(commitFreehandRepair).not.toHaveBeenCalled();
   });
 
   it("does not start freehand drawing on a read-only annotation", () => {

--- a/web/libs/editor/src/regions/PolygonRegion.jsx
+++ b/web/libs/editor/src/regions/PolygonRegion.jsx
@@ -18,6 +18,7 @@ import { AliveRegion } from "./AliveRegion";
 import { KonvaRegionMixin } from "../mixins/KonvaRegion";
 import { observer } from "mobx-react";
 import { createDragBoundFunc } from "../utils/image";
+import { isValidFreehandContour } from "../utils/freehand";
 import { ImageViewContext } from "../components/ImageView/ImageViewContext";
 
 const Model = types
@@ -39,6 +40,7 @@ const Model = types
     preferTransformer: false,
     supportsRotate: false,
     supportsScale: true,
+    edgeClickGuard: null,
   }))
   .views((self) => ({
     get store() {
@@ -72,6 +74,22 @@ const Model = types
     },
   }))
   .actions((self) => {
+    const shouldSuppressEdgeClick = (event) => {
+      const guard = self.edgeClickGuard;
+
+      self.edgeClickGuard = null;
+      if (!guard || Date.now() >= guard.expiresAt) return false;
+
+      const x = Number.isFinite(event?.clientX) ? event.clientX : event?.offsetX;
+      const y = Number.isFinite(event?.clientY) ? event.clientY : event?.offsetY;
+      const deltaX = x - guard.clientX;
+      const deltaY = y - guard.clientY;
+
+      return (
+        Number.isFinite(deltaX) && Number.isFinite(deltaY) && deltaX * deltaX + deltaY * deltaY <= guard.radius ** 2
+      );
+    };
+
     return {
       afterCreate() {
         if (!self.points.length) return;
@@ -127,6 +145,7 @@ const Model = types
         if (!self.closed || !self.selected) return;
 
         e.cancelBubble = true;
+        if (self.consumeEdgeClickGuard(e.evt)) return;
 
         removeHoverAnchor({ layer: e.currentTarget.getLayer() });
 
@@ -136,6 +155,15 @@ const Model = types
         const point = getAnchorPoint({ flattenedPoints, cursorX, cursorY });
 
         self.insertPoint(insertIdx, point[0], point[1]);
+      },
+
+      suppressNextEdgeClick({ clientX, clientY, expiresAt, radius }) {
+        if (![clientX, clientY, expiresAt, radius].every(Number.isFinite) || radius < 0) return;
+        self.edgeClickGuard = { clientX, clientY, expiresAt, radius };
+      },
+
+      consumeEdgeClickGuard(event) {
+        return shouldSuppressEdgeClick(event);
       },
 
       deletePoint(point) {
@@ -161,6 +189,87 @@ const Model = types
           p.x = points[idx * 2];
           p.y = points[idx * 2 + 1];
         });
+      },
+
+      replacePoints(points) {
+        if (!Array.isArray(points) || points.length < 3) return false;
+
+        const snappedPoints = points.map((point) => {
+          const x = Array.isArray(point) ? point[0] : point?.x;
+          const y = Array.isArray(point) ? point[1] : point?.y;
+          const snappedPoint =
+            Number.isFinite(x) && Number.isFinite(y) ? (self.control?.getSnappedPoint?.({ x, y }) ?? { x, y }) : null;
+
+          return snappedPoint;
+        });
+
+        if (snappedPoints.some((point) => !point || !Number.isFinite(point.x) || !Number.isFinite(point.y))) {
+          return false;
+        }
+
+        const normalizedPoints = snappedPoints.reduce((result, point) => {
+          const previous = result[result.length - 1];
+
+          if (!previous || previous.x !== point.x || previous.y !== point.y) result.push(point);
+          return result;
+        }, []);
+
+        const firstPoint = normalizedPoints[0];
+        const lastPoint = normalizedPoints[normalizedPoints.length - 1];
+
+        if (firstPoint && lastPoint && firstPoint.x === lastPoint.x && firstPoint.y === lastPoint.y) {
+          normalizedPoints.pop();
+        }
+        if (normalizedPoints.length < 3) return false;
+
+        if (
+          normalizedPoints.length === self.points.length &&
+          normalizedPoints.every(({ x, y }, index) => self.points[index].x === x && self.points[index].y === y)
+        ) {
+          return false;
+        }
+
+        const uniquePoints = new Set(normalizedPoints.map(({ x, y }) => `${x}:${y}`));
+
+        if (uniquePoints.size !== normalizedPoints.length) return false;
+
+        const signedDoubleArea = normalizedPoints.reduce((area, point, index) => {
+          const next = normalizedPoints[(index + 1) % normalizedPoints.length];
+
+          return area + point.x * next.y - next.x * point.y;
+        }, 0);
+        const previousSignedDoubleArea = self.points.reduce((area, point, index) => {
+          const next = self.points[(index + 1) % self.points.length];
+
+          return area + point.x * next.y - next.x * point.y;
+        }, 0);
+
+        if (Math.abs(signedDoubleArea) < 1e-12) return false;
+        if (
+          Math.sign(previousSignedDoubleArea) !== 0 &&
+          Math.sign(signedDoubleArea) !== Math.sign(previousSignedDoubleArea)
+        ) {
+          return false;
+        }
+        if (!isValidFreehandContour(normalizedPoints)) return false;
+
+        const pointSize = self.points[0]?.size ?? self.pointSize ?? "small";
+        const pointStyle = self.points[0]?.style ?? self.pointStyle ?? "circle";
+
+        if (self.selectedPoint) self.selectedPoint.selected = false;
+        self.selectedPoint = null;
+        self.points.replace(
+          normalizedPoints.map(({ x, y }, index) => ({
+            id: guidGenerator(),
+            x,
+            y,
+            size: pointSize,
+            style: pointStyle,
+            index,
+          })),
+        );
+
+        return true;
       },
 
       insertPoint(insertIdx, x, y) {

--- a/web/libs/editor/src/regions/__tests__/PolygonRegion.test.jsx
+++ b/web/libs/editor/src/regions/__tests__/PolygonRegion.test.jsx
@@ -241,6 +241,149 @@ describe("PolygonRegion", () => {
       expect(region.points[2].y).toBe(20);
     });
 
+    it("replacePoints safely rebuilds a contour with a different number of points", () => {
+      const previousIds = region.points.map((point) => point.id);
+
+      region.setSelectedPoint(region.points[1]);
+
+      expect(
+        region.replacePoints([
+          [5, 5],
+          [30, 0],
+          [60, 20],
+          [45, 60],
+          [5, 45],
+        ]),
+      ).toBe(true);
+      expect(region.selectedPoint).toBeNull();
+      expect(region.points).toHaveLength(5);
+      expect(region.points.map(({ x, y }) => [x, y])).toEqual([
+        [5, 5],
+        [30, 0],
+        [60, 20],
+        [45, 60],
+        [5, 45],
+      ]);
+      expect(region.points.map((point) => point.index)).toEqual([0, 1, 2, 3, 4]);
+      expect(region.points.every((point) => !previousIds.includes(point.id))).toBe(true);
+
+      expect(
+        region.replacePoints([
+          { x: 10, y: 10 },
+          { x: 40, y: 10 },
+          { x: 25, y: 40 },
+        ]),
+      ).toBe(true);
+      expect(region.points).toHaveLength(3);
+      expect(region.points.map(({ x, y }) => [x, y])).toEqual([
+        [10, 10],
+        [40, 10],
+        [25, 40],
+      ]);
+    });
+
+    it("replacePoints rejects malformed or degenerate contours without changing the region", () => {
+      const originalPoints = region.points.map(({ id, x, y, index }) => ({ id, x, y, index }));
+
+      expect(
+        region.replacePoints([
+          [0, 0],
+          [10, 10],
+        ]),
+      ).toBe(false);
+      expect(
+        region.replacePoints([
+          [0, 0],
+          [10, Number.NaN],
+          [20, 20],
+        ]),
+      ).toBe(false);
+      expect(
+        region.replacePoints([
+          [10, 10],
+          [10, 10],
+          [10, 10],
+        ]),
+      ).toBe(false);
+      expect(region.points.map(({ id, x, y, index }) => ({ id, x, y, index }))).toEqual(originalPoints);
+    });
+
+    it("normalizes duplicate adjacent and closing points before rebuilding", () => {
+      expect(
+        region.replacePoints([
+          [0, 0],
+          [0, 0],
+          [50, 0],
+          [50, 50],
+          [0, 50],
+          [0, 0],
+        ]),
+      ).toBe(true);
+      expect(region.points.map(({ x, y }) => [x, y])).toEqual([
+        [0, 0],
+        [50, 0],
+        [50, 50],
+        [0, 50],
+      ]);
+    });
+
+    it("rejects a zero-area contour after normalization", () => {
+      const originalPoints = region.points.map(({ x, y }) => [x, y]);
+
+      expect(
+        region.replacePoints([
+          [0, 0],
+          [10, 0],
+          [20, 0],
+        ]),
+      ).toBe(false);
+      expect(region.points.map(({ x, y }) => [x, y])).toEqual(originalPoints);
+    });
+
+    it("rejects a self-intersecting contour after snapping without changing the region", () => {
+      const originalPoints = region.points.map(({ id, x, y, index }) => ({ id, x, y, index }));
+
+      expect(
+        region.replacePoints([
+          [10, 10],
+          [12, 11],
+          [10, 12],
+          [11, 10],
+        ]),
+      ).toBe(false);
+      expect(region.points.map(({ id, x, y, index }) => ({ id, x, y, index }))).toEqual(originalPoints);
+    });
+
+    it("consumes one nearby compatibility click after a freehand repair", () => {
+      region.suppressNextEdgeClick({
+        clientX: 50,
+        clientY: 20,
+        expiresAt: Date.now() + 1000,
+        radius: 25,
+      });
+
+      expect(region.consumeEdgeClickGuard({ clientX: 55, clientY: 25 })).toBe(true);
+      expect(region.consumeEdgeClickGuard({ clientX: 55, clientY: 25 })).toBe(false);
+    });
+
+    it("does not suppress an expired or distant edge click", () => {
+      region.suppressNextEdgeClick({
+        clientX: 50,
+        clientY: 20,
+        expiresAt: Date.now() - 1,
+        radius: 25,
+      });
+      expect(region.consumeEdgeClickGuard({ clientX: 50, clientY: 20 })).toBe(false);
+
+      region.suppressNextEdgeClick({
+        clientX: 50,
+        clientY: 20,
+        expiresAt: Date.now() + 1000,
+        radius: 25,
+      });
+      expect(region.consumeEdgeClickGuard({ clientX: 100, clientY: 20 })).toBe(false);
+    });
+
     it("afterUnselectRegion clears selectedPoint.selected", () => {
       const firstPoint = region.points[0];
       region.setSelectedPoint(firstPoint);

--- a/web/libs/editor/src/tools/Polygon.js
+++ b/web/libs/editor/src/tools/Polygon.js
@@ -121,7 +121,7 @@ const _Tool = types
       if (region.type !== "polygonregion" || !region.closed || region.hidden || region.filtered) return false;
       if (region.isDrawing || region.locked || region.readonly) return false;
       if (annotation?.editable === false || annotation?.isDrawing || annotation?.isReadOnly?.()) return false;
-      if (region.isReadOnly?.() !== false) return false;
+      if (region.isReadOnly?.()) return false;
       if (region.annotation !== annotation || region.object !== self.obj || region.control !== self.control)
         return false;
       if (typeof region.replacePoints !== "function" || typeof region.notifyDrawingFinished !== "function")

--- a/web/libs/editor/src/tools/Polygon.js
+++ b/web/libs/editor/src/tools/Polygon.js
@@ -6,6 +6,9 @@ import ToolMixin from "../mixins/Tool";
 import { MultipleClicksDrawingTool } from "../mixins/DrawingTool";
 import { NodeViews } from "../components/Node/Node";
 import { observe } from "mobx";
+import { FF_POLYGON_FREEHAND, isFF } from "../utils/feature-flags";
+
+const FREEHAND_HISTORY_KEY = "polygon-freehand";
 
 const _Tool = types
   .model("PolygonTool", {
@@ -75,10 +78,76 @@ const _Tool = types
   .actions((self) => {
     let disposer;
     let closed;
+    let freehandHistoryFrozen = false;
+    let freehandFinishTimer = null;
+
+    const releaseFreehandHistory = () => {
+      if (!freehandHistoryFrozen) return;
+      freehandHistoryFrozen = false;
+      self.annotation.history.unfreeze(FREEHAND_HISTORY_KEY);
+    };
+
+    const finishFreehandDrawing = () => {
+      if (!self.isDrawing || !self.getCurrentArea()) {
+        releaseFreehandHistory();
+        return false;
+      }
+
+      self.annotation.regionStore.selection.drawingUnselect();
+      self.closeCurrent();
+      freehandFinishTimer = setTimeout(() => {
+        freehandFinishTimer = null;
+        if (!isAlive(self) || !self.isDrawing || !self.annotation.isDrawing || !self.getCurrentArea()) {
+          releaseFreehandHistory();
+          return;
+        }
+        self._finishDrawing();
+      });
+      return true;
+    };
 
     return {
+      canStartFreehand() {
+        return isFF(FF_POLYGON_FREEHAND) && self.canStartDrawing();
+      },
+      commitFreehand(points) {
+        if (!Array.isArray(points) || points.length < 3 || !self.canStartFreehand()) return false;
+
+        const validPoints = points.filter(
+          (point) => Array.isArray(point) && Number.isFinite(point[0]) && Number.isFinite(point[1]),
+        );
+
+        if (validPoints.length < 3) return false;
+
+        self.stopListening();
+        closed = false;
+        self.annotation.history.freeze(FREEHAND_HISTORY_KEY);
+        freehandHistoryFrozen = true;
+        try {
+          self.startDrawing(validPoints[0][0], validPoints[0][1]);
+
+          if (!self.isDrawing || !self.getCurrentArea()) {
+            releaseFreehandHistory();
+            return false;
+          }
+
+          validPoints.slice(1).forEach(([x, y]) => self.nextPoint(x, y));
+          if (self.getCurrentArea().points.length < 3) {
+            self.cleanupUncloseableShape();
+            releaseFreehandHistory();
+            return false;
+          }
+
+          return finishFreehandDrawing();
+        } catch (error) {
+          releaseFreehandHistory();
+          throw error;
+        }
+      },
       handleToolSwitch(tool) {
         self.stopListening();
+        releaseFreehandHistory();
+        if (freehandFinishTimer !== null) return;
         if (self.getCurrentArea()?.isDrawing && tool.toolName !== "ZoomPanTool") {
           const shape = self.getCurrentArea()?.toJSON();
 
@@ -100,7 +169,16 @@ const _Tool = types
         );
       },
       stopListening() {
-        if (disposer) disposer();
+        if (disposer) {
+          disposer();
+          disposer = null;
+        }
+      },
+      beforeDestroy() {
+        self.stopListening();
+        if (freehandFinishTimer !== null) clearTimeout(freehandFinishTimer);
+        freehandFinishTimer = null;
+        releaseFreehandHistory();
       },
       closeCurrent() {
         self.stopListening();
@@ -121,13 +199,17 @@ const _Tool = types
       },
 
       _finishDrawing() {
-        const { currentArea, control } = self;
+        try {
+          const { currentArea, control } = self;
 
-        self.currentArea.notifyDrawingFinished();
-        self.setDrawing(false);
-        self.currentArea = null;
-        self.mode = "viewing";
-        self.annotation.afterCreateResult(currentArea, control);
+          self.currentArea.notifyDrawingFinished();
+          self.setDrawing(false);
+          self.currentArea = null;
+          self.mode = "viewing";
+          self.annotation.afterCreateResult(currentArea, control);
+        } finally {
+          releaseFreehandHistory();
+        }
       },
 
       setDrawing(drawing) {

--- a/web/libs/editor/src/tools/Polygon.js
+++ b/web/libs/editor/src/tools/Polygon.js
@@ -1,5 +1,5 @@
 import { ff } from "@humansignal/core";
-import { isAlive, types } from "mobx-state-tree";
+import { isAlive, isStateTreeNode, types } from "mobx-state-tree";
 
 import BaseTool, { DEFAULT_DIMENSIONS } from "./Base";
 import ToolMixin from "../mixins/Tool";
@@ -7,8 +7,10 @@ import { MultipleClicksDrawingTool } from "../mixins/DrawingTool";
 import { NodeViews } from "../components/Node/Node";
 import { observe } from "mobx";
 import { FF_POLYGON_FREEHAND, isFF } from "../utils/feature-flags";
+import { isValidFreehandContour } from "../utils/freehand";
 
 const FREEHAND_HISTORY_KEY = "polygon-freehand";
+const FREEHAND_REPAIR_HISTORY_KEY = "polygon-contour-repair";
 
 const _Tool = types
   .model("PolygonTool", {
@@ -106,18 +108,63 @@ const _Tool = types
       return true;
     };
 
+    const isFreehandRepairTarget = (region) => {
+      const annotation = self.annotation;
+      const selectedRegions = annotation?.selectedRegions;
+
+      if (!isFF(FF_POLYGON_FREEHAND)) return false;
+      if (self.disabled || self.isDrawing) return false;
+      if (!region || (isStateTreeNode(region) && !isAlive(region))) return false;
+      if (!Array.isArray(selectedRegions) || selectedRegions.length !== 1 || selectedRegions[0] !== region) {
+        return false;
+      }
+      if (region.type !== "polygonregion" || !region.closed || region.hidden || region.filtered) return false;
+      if (region.isDrawing || region.locked || region.readonly) return false;
+      if (annotation?.editable === false || annotation?.isDrawing || annotation?.isReadOnly?.()) return false;
+      if (region.isReadOnly?.() !== false) return false;
+      if (region.annotation !== annotation || region.object !== self.obj || region.control !== self.control)
+        return false;
+      if (typeof region.replacePoints !== "function" || typeof region.notifyDrawingFinished !== "function")
+        return false;
+
+      return true;
+    };
+
+    const hasValidFreehandRepairPoints = (points) =>
+      Array.isArray(points) &&
+      points.length >= 3 &&
+      points.every((point) => {
+        const x = Array.isArray(point) ? point[0] : point?.x;
+        const y = Array.isArray(point) ? point[1] : point?.y;
+
+        return Number.isFinite(x) && Number.isFinite(y);
+      });
+
     return {
+      canRepairFreehand(region) {
+        return isFreehandRepairTarget(region);
+      },
+      commitFreehandRepair(region, points) {
+        if (!isFreehandRepairTarget(region) || !hasValidFreehandRepairPoints(points)) return false;
+
+        self.annotation.history.freeze(FREEHAND_REPAIR_HISTORY_KEY);
+        try {
+          const replaced = region.replacePoints(points);
+
+          if (!replaced) return false;
+          region.notifyDrawingFinished();
+          return true;
+        } finally {
+          self.annotation.history.unfreeze(FREEHAND_REPAIR_HISTORY_KEY);
+        }
+      },
       canStartFreehand() {
         return isFF(FF_POLYGON_FREEHAND) && self.canStartDrawing();
       },
       commitFreehand(points) {
         if (!Array.isArray(points) || points.length < 3 || !self.canStartFreehand()) return false;
-
-        const validPoints = points.filter(
-          (point) => Array.isArray(point) && Number.isFinite(point[0]) && Number.isFinite(point[1]),
-        );
-
-        if (validPoints.length < 3) return false;
+        if (!isValidFreehandContour(points)) return false;
+        const validPoints = points;
 
         self.stopListening();
         closed = false;

--- a/web/libs/editor/src/tools/__tests__/Polygon.test.js
+++ b/web/libs/editor/src/tools/__tests__/Polygon.test.js
@@ -82,8 +82,25 @@ const createPolygonTool = () => {
   const manager = { name: "image", obj: object, findSelectedTool: jest.fn(), selectTool: jest.fn() };
   const tool = Polygon.create({}, { manager, control, object });
 
-  return { tool, annotation, history, area };
+  return { tool, annotation, history, area, control, object };
 };
+
+const createRepairRegion = ({ annotation, control, object }, overrides = {}) => ({
+  type: "polygonregion",
+  closed: true,
+  hidden: false,
+  filtered: false,
+  locked: false,
+  readonly: false,
+  isDrawing: false,
+  annotation,
+  control,
+  object,
+  isReadOnly: jest.fn(() => false),
+  replacePoints: jest.fn(() => true),
+  notifyDrawingFinished: jest.fn(),
+  ...overrides,
+});
 
 describe("Polygon freehand", () => {
   beforeEach(() => {
@@ -135,6 +152,24 @@ describe("Polygon freehand", () => {
     expect(history.unfreeze).toHaveBeenCalledWith("polygon-freehand");
   });
 
+  it("rejects a self-touching creation contour before creating a region", () => {
+    mockFreehandEnabled = true;
+    const { tool, annotation, history } = createPolygonTool();
+
+    expect(
+      tool.commitFreehand([
+        [10, 10],
+        [100, 50],
+        [100, 100],
+        [50, 100],
+        [100, 100],
+        [90, 90],
+      ]),
+    ).toBe(false);
+    expect(annotation.createResult).not.toHaveBeenCalled();
+    expect(history.freeze).not.toHaveBeenCalled();
+  });
+
   it("releases history when deferred completion is skipped", () => {
     mockFreehandEnabled = true;
     const { tool, annotation, history, area } = createPolygonTool();
@@ -173,5 +208,96 @@ describe("Polygon freehand", () => {
     jest.runOnlyPendingTimers();
     expect(annotation.afterCreateResult).toHaveBeenCalledTimes(1);
     expect(history.unfreeze).toHaveBeenCalledTimes(1);
+  });
+
+  it("only allows repairing the one selected editable polygon from the same tool context", () => {
+    mockFreehandEnabled = true;
+    const context = createPolygonTool();
+    const region = createRepairRegion(context);
+    const expectRejected = (overrides) => {
+      const candidate = createRepairRegion(context, overrides);
+
+      context.annotation.selectedRegions = [candidate];
+      expect(context.tool.canRepairFreehand(candidate)).toBe(false);
+    };
+
+    context.annotation.selectedRegions = [region];
+
+    expect(context.tool.canRepairFreehand(region)).toBe(true);
+
+    context.annotation.selectedRegions = [region, createRepairRegion(context)];
+    expect(context.tool.canRepairFreehand(region)).toBe(false);
+
+    expectRejected({ closed: false });
+    expectRejected({ hidden: true });
+    expectRejected({ isReadOnly: () => true });
+    expectRejected({ object: {} });
+    expectRejected({ control: {} });
+    expectRejected({ annotation: {} });
+  });
+
+  it("does not allow contour repair when the feature flag is off", () => {
+    const context = createPolygonTool();
+    const region = createRepairRegion(context);
+
+    context.annotation.selectedRegions = [region];
+
+    expect(context.tool.canRepairFreehand(region)).toBe(false);
+    expect(
+      context.tool.commitFreehandRepair(region, [
+        [10, 10],
+        [20, 10],
+        [20, 20],
+      ]),
+    ).toBe(false);
+    expect(context.history.freeze).not.toHaveBeenCalled();
+  });
+
+  it("repairs the selected polygon in one synchronous history transaction", () => {
+    mockFreehandEnabled = true;
+    const context = createPolygonTool();
+    const region = createRepairRegion(context);
+    const points = [
+      [10, 10],
+      [25, 5],
+      [30, 20],
+      [10, 20],
+    ];
+
+    context.annotation.selectedRegions = [region];
+
+    expect(context.tool.commitFreehandRepair(region, points)).toBe(true);
+    expect(context.history.freeze).toHaveBeenCalledTimes(1);
+    expect(context.history.freeze).toHaveBeenCalledWith("polygon-contour-repair");
+    expect(region.replacePoints).toHaveBeenCalledTimes(1);
+    expect(region.replacePoints).toHaveBeenCalledWith(points);
+    expect(region.notifyDrawingFinished).toHaveBeenCalledTimes(1);
+    expect(context.annotation.createResult).not.toHaveBeenCalled();
+    expect(context.annotation.afterCreateResult).not.toHaveBeenCalled();
+    expect(context.history.unfreeze).toHaveBeenCalledTimes(1);
+    expect(context.history.unfreeze).toHaveBeenCalledWith("polygon-contour-repair");
+  });
+
+  it("always releases contour-repair history when replacement fails", () => {
+    mockFreehandEnabled = true;
+    const context = createPolygonTool();
+    const error = new Error("replacement failed");
+    const region = createRepairRegion(context);
+
+    region.replacePoints = jest.fn(() => {
+      throw error;
+    });
+    context.annotation.selectedRegions = [region];
+
+    expect(() =>
+      context.tool.commitFreehandRepair(region, [
+        [10, 10],
+        [20, 10],
+        [20, 20],
+      ]),
+    ).toThrow(error);
+    expect(region.notifyDrawingFinished).not.toHaveBeenCalled();
+    expect(context.history.unfreeze).toHaveBeenCalledTimes(1);
+    expect(context.history.unfreeze).toHaveBeenCalledWith("polygon-contour-repair");
   });
 });

--- a/web/libs/editor/src/tools/__tests__/Polygon.test.js
+++ b/web/libs/editor/src/tools/__tests__/Polygon.test.js
@@ -1,0 +1,177 @@
+let mockFreehandEnabled = false;
+
+jest.mock("../../utils/feature-flags", () => ({
+  FF_DEV_3391: "fflag_fix_front_dev_3391_interactive_view_all",
+  FF_SIMPLE_INIT: "fflag_fix_front_leap_443_select_annotation_once",
+  FF_POLYGON_FREEHAND: "fflag_feat_front_polygon_freehand",
+  isFF: jest.fn((flag) => {
+    if (flag === "fflag_feat_front_polygon_freehand") return mockFreehandEnabled;
+    return flag === "fflag_fix_front_dev_3391_interactive_view_all";
+  }),
+}));
+
+jest.mock("@humansignal/core", () => ({
+  ff: {
+    FF_MULTIPLE_LABELS_REGIONS: "fflag_multiple_labels_regions",
+    isActive: jest.fn(() => false),
+  },
+}));
+
+jest.mock("../../components/Node/Node", () => ({
+  NodeViews: { PolygonRegionModel: { icon: jest.fn(), altIcon: jest.fn() } },
+}));
+
+const { Polygon } = require("../Polygon");
+
+const createPolygonTool = () => {
+  const history = { freeze: jest.fn(), unfreeze: jest.fn() };
+  const selection = { drawingUnselect: jest.fn(), hasSelection: false };
+  const annotation = {
+    editable: true,
+    isDrawing: false,
+    isReadOnly: jest.fn(() => false),
+    history,
+    regionStore: { selection, hasSelection: false },
+    setIsDrawing: jest.fn((drawing) => {
+      annotation.isDrawing = drawing;
+    }),
+    afterCreateResult: jest.fn(),
+    unselectAll: jest.fn(),
+  };
+  const control = {
+    type: "polygonlabels",
+    isSelected: true,
+    isSeparated: false,
+    annotation,
+    getResultValue: jest.fn(() => ({})),
+    getSnappedPoint: jest.fn(({ x, y }) => ({ x, y })),
+  };
+  const area = {
+    type: "polygonregion",
+    closed: false,
+    isDrawing: true,
+    points: [],
+    setValue: jest.fn(),
+    setDrawing: jest.fn((drawing) => {
+      area.isDrawing = drawing;
+    }),
+    addPoint: jest.fn((x, y) => area.points.push({ x, y })),
+    closePoly: jest.fn(() => {
+      area.closed = true;
+    }),
+    notifyDrawingFinished: jest.fn(),
+    toJSON: jest.fn(() => ({ points: area.points.map(({ x, y }) => [x, y]) })),
+  };
+  annotation.createResult = jest.fn((options) => {
+    area.points = options.points.map(([x, y]) => ({ x, y }));
+    return area;
+  });
+  const object = {
+    name: "image",
+    annotation,
+    regs: [],
+    canvasSize: { width: 100, height: 100 },
+    stageScale: 1,
+    stageWidth: 100,
+    stageHeight: 100,
+    multiImage: false,
+    currentImage: 0,
+    checkLabels: jest.fn(() => true),
+    activeStates: jest.fn(() => []),
+  };
+  const manager = { name: "image", obj: object, findSelectedTool: jest.fn(), selectTool: jest.fn() };
+  const tool = Polygon.create({}, { manager, control, object });
+
+  return { tool, annotation, history, area };
+};
+
+describe("Polygon freehand", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockFreehandEnabled = false;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("does not create a contour when the feature flag is off", () => {
+    const { tool, history } = createPolygonTool();
+
+    expect(tool.canStartFreehand()).toBe(false);
+    expect(
+      tool.commitFreehand([
+        [10, 10],
+        [20, 10],
+        [20, 20],
+      ]),
+    ).toBe(false);
+    expect(history.freeze).not.toHaveBeenCalled();
+  });
+
+  it("commits one contour inside a single history transaction", () => {
+    mockFreehandEnabled = true;
+    const { tool, annotation, history, area } = createPolygonTool();
+
+    expect(
+      tool.commitFreehand([
+        [10, 10],
+        [20, 10],
+        [20, 20],
+        [10, 20],
+      ]),
+    ).toBe(true);
+    expect(history.freeze).toHaveBeenCalledTimes(1);
+    expect(history.freeze).toHaveBeenCalledWith("polygon-freehand");
+
+    jest.runOnlyPendingTimers();
+
+    expect(area.points).toHaveLength(4);
+    expect(area.closed).toBe(true);
+    expect(annotation.afterCreateResult).toHaveBeenCalledTimes(1);
+    expect(history.unfreeze).toHaveBeenCalledTimes(1);
+    expect(history.unfreeze).toHaveBeenCalledWith("polygon-freehand");
+  });
+
+  it("releases history when deferred completion is skipped", () => {
+    mockFreehandEnabled = true;
+    const { tool, annotation, history, area } = createPolygonTool();
+
+    expect(
+      tool.commitFreehand([
+        [10, 10],
+        [20, 10],
+        [20, 20],
+      ]),
+    ).toBe(true);
+    area.setDrawing(false);
+    annotation.setIsDrawing(false);
+
+    jest.runOnlyPendingTimers();
+
+    expect(annotation.afterCreateResult).not.toHaveBeenCalled();
+    expect(history.unfreeze).toHaveBeenCalledTimes(1);
+    expect(history.unfreeze).toHaveBeenCalledWith("polygon-freehand");
+  });
+
+  it("releases history synchronously on a tool switch without double-finishing", () => {
+    mockFreehandEnabled = true;
+    const { tool, annotation, history } = createPolygonTool();
+
+    expect(
+      tool.commitFreehand([
+        [10, 10],
+        [20, 10],
+        [20, 20],
+      ]),
+    ).toBe(true);
+    tool.handleToolSwitch({ toolName: "RectangleTool" });
+
+    expect(history.unfreeze).toHaveBeenCalledTimes(1);
+    jest.runOnlyPendingTimers();
+    expect(annotation.afterCreateResult).toHaveBeenCalledTimes(1);
+    expect(history.unfreeze).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/libs/editor/src/tools/__tests__/Polygon.test.js
+++ b/web/libs/editor/src/tools/__tests__/Polygon.test.js
@@ -225,6 +225,9 @@ describe("Polygon freehand", () => {
 
     expect(context.tool.canRepairFreehand(region)).toBe(true);
 
+    region.isReadOnly.mockReturnValue(undefined);
+    expect(context.tool.canRepairFreehand(region)).toBe(true);
+
     context.annotation.selectedRegions = [region, createRepairRegion(context)];
     expect(context.tool.canRepairFreehand(region)).toBe(false);
 

--- a/web/libs/editor/src/utils/__tests__/freehand.test.js
+++ b/web/libs/editor/src/utils/__tests__/freehand.test.js
@@ -1,4 +1,13 @@
-import { appendFreehandPoint, simplifyFreehandPoints } from "../freehand";
+import {
+  appendFreehandPoint,
+  buildFreehandRepairContour,
+  findNearestContourPoint,
+  FREEHAND_REPAIR_MIN_RAW_POINTS,
+  FREEHAND_REPAIR_SNAP_RADIUS,
+  hasFreehandContourSelfIntersection,
+  isValidFreehandContour,
+  simplifyFreehandPoints,
+} from "../freehand";
 
 describe("freehand utilities", () => {
   it("keeps only endpoints for a straight trace", () => {
@@ -48,5 +57,281 @@ describe("freehand utilities", () => {
       { x: 1, y: 1 },
       { x: 4, y: 1 },
     ]);
+  });
+
+  it("validates closed contours without misclassifying the wraparound edge", () => {
+    const triangle = [
+      { x: 1, y: 0 },
+      { x: 2, y: 1 },
+      { x: 0, y: 1 },
+    ];
+
+    expect(hasFreehandContourSelfIntersection(triangle)).toBe(false);
+    expect(isValidFreehandContour(triangle)).toBe(true);
+    expect(hasFreehandContourSelfIntersection(triangle, { maxComparisons: 0 })).toBeNull();
+    expect(
+      hasFreehandContourSelfIntersection([
+        [0, 0],
+        [10, 10],
+        [0, 10],
+        [10, 0],
+      ]),
+    ).toBe(true);
+  });
+
+  it("detects intersections introduced when valid input points are snapped", () => {
+    const beforeSnapping = [
+      [10.1043889262, 9.770172186],
+      [12.4084808717, 10.9182869663],
+      [10.4475965089, 11.7840321064],
+      [11.0435366642, 10.279983292],
+    ];
+    const afterSnapping = beforeSnapping.map(([x, y]) => [Math.round(x), Math.round(y)]);
+
+    expect(hasFreehandContourSelfIntersection(beforeSnapping)).toBe(false);
+    expect(hasFreehandContourSelfIntersection(afterSnapping)).toBe(true);
+    expect(isValidFreehandContour(afterSnapping)).toBe(false);
+  });
+
+  describe("contour repair", () => {
+    const square = [
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ];
+
+    const signedArea = (points) =>
+      points.reduce((area, point, index) => {
+        const next = points[(index + 1) % points.length];
+        return area + point.x * next.y - next.x * point.y;
+      }, 0);
+
+    it("exposes stable gesture defaults", () => {
+      expect(FREEHAND_REPAIR_MIN_RAW_POINTS).toBe(8);
+      expect(FREEHAND_REPAIR_SNAP_RADIUS).toBe(12);
+    });
+
+    it("projects a canvas point onto the nearest closed-contour segment", () => {
+      expect(findNearestContourPoint(square, { x: 4, y: 3 })).toMatchObject({
+        point: { x: 4, y: 0 },
+        segmentIndex: 0,
+        t: 0.4,
+        position: 0.4,
+        distance: 3,
+        perimeterOffset: 4,
+        perimeter: 40,
+      });
+      expect(findNearestContourPoint(square, [-1, 5])).toMatchObject({
+        point: { x: 0, y: 5 },
+        segmentIndex: 3,
+        t: 0.5,
+        position: 3.5,
+      });
+    });
+
+    it("snaps endpoints and replaces the boundary arc nearest the trace", () => {
+      const repair = buildFreehandRepairContour(
+        square,
+        [
+          [0, 1],
+          [4, 4],
+          [10, 1],
+        ],
+        { snapRadius: 2 },
+      );
+
+      expect(repair).toMatchObject({
+        replacedArc: "forward",
+        startAnchor: { point: { x: 0, y: 1 }, segmentIndex: 3 },
+        endAnchor: { point: { x: 10, y: 1 }, segmentIndex: 1 },
+      });
+      expect(repair.points).toEqual([
+        { x: 0, y: 1 },
+        { x: 4, y: 4 },
+        { x: 10, y: 1 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ]);
+    });
+
+    it("handles a replaced arc that wraps across the contour's last vertex", () => {
+      const repair = buildFreehandRepairContour(
+        square,
+        [
+          [0, 8],
+          [-2, 4],
+          [2, 0],
+        ],
+        { snapRadius: 0 },
+      );
+
+      expect(repair.replacedArc).toBe("forward");
+      expect(repair.points).toEqual([
+        { x: 0, y: 8 },
+        { x: -2, y: 4 },
+        { x: 2, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ]);
+    });
+
+    it("preserves winding when the same local repair is drawn in reverse", () => {
+      const repair = buildFreehandRepairContour(
+        square,
+        [
+          [8, 0],
+          [5, -2],
+          [2, 0],
+        ],
+        { snapRadius: 0 },
+      );
+
+      expect(repair.replacedArc).toBe("backward");
+      expect(repair.points).toEqual([
+        { x: 8, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+        { x: 0, y: 0 },
+        { x: 2, y: 0 },
+        { x: 5, y: -2 },
+      ]);
+      expect(Math.sign(signedArea(repair.points))).toBe(Math.sign(signedArea(square.map(([x, y]) => ({ x, y })))));
+    });
+
+    it("uses trace proximity before length, allowing an intended long-arc repair", () => {
+      const repair = buildFreehandRepairContour(
+        square,
+        [
+          [0, 0],
+          [-2, 5],
+          [0, 10],
+          [10, 10],
+          [12, 5],
+          [10, 0],
+        ],
+        { snapRadius: 0 },
+      );
+
+      expect(repair.replacedArc).toBe("backward");
+      expect(repair.points).toEqual([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 12, y: 5 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+        { x: -2, y: 5 },
+      ]);
+    });
+
+    it("uses the shorter boundary arc only when proximity is effectively tied", () => {
+      const tinySquare = [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+      ];
+      const repair = buildFreehandRepairContour(tinySquare, [
+        [0, 0],
+        [0.5, -0.1],
+        [1, 0],
+      ]);
+
+      expect(repair.replacedArc).toBe("forward");
+    });
+
+    it("rejects an ambiguous equal-proximity, equal-length repair", () => {
+      expect(
+        buildFreehandRepairContour(
+          square,
+          [
+            [0, 5],
+            [5, 5],
+            [10, 5],
+          ],
+          { snapRadius: 0 },
+        ),
+      ).toBeNull();
+    });
+
+    it("rejects unsnapped or coincident endpoints", () => {
+      expect(
+        buildFreehandRepairContour(
+          square,
+          [
+            [5, 5],
+            [7, 7],
+            [10, 1],
+          ],
+          { snapRadius: 2 },
+        ),
+      ).toBeNull();
+      expect(
+        buildFreehandRepairContour(
+          square,
+          [
+            [0, 1],
+            [2, 2],
+            [0, 1],
+          ],
+          { snapRadius: 2 },
+        ),
+      ).toBeNull();
+    });
+
+    it("rejects invalid source contours and self-degenerate repaired contours", () => {
+      const selfIntersectingContour = [
+        [0, 0],
+        [10, 10],
+        [0, 10],
+        [10, 0],
+      ];
+
+      expect(buildFreehandRepairContour(selfIntersectingContour, square.slice(0, 3))).toBeNull();
+      expect(
+        buildFreehandRepairContour(
+          square,
+          [
+            [2, 0],
+            [12, 5],
+            [5, 12],
+            [8, 0],
+          ],
+          { snapRadius: 0 },
+        ),
+      ).toBeNull();
+      expect(
+        buildFreehandRepairContour(square, [
+          [0, 1],
+          [Number.NaN, 2],
+          [10, 1],
+        ]),
+      ).toBeNull();
+    });
+
+    it("preserves a clockwise source contour without adding a repeated closing point", () => {
+      const clockwiseSquare = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const repair = buildFreehandRepairContour(
+        clockwiseSquare,
+        [
+          [0, 2],
+          [-2, 5],
+          [0, 8],
+        ],
+        { snapRadius: 0 },
+      );
+
+      expect(repair).not.toBeNull();
+      expect(Math.sign(signedArea(repair.points))).toBe(-1);
+      expect(repair.points[repair.points.length - 1]).not.toEqual(repair.points[0]);
+    });
   });
 });

--- a/web/libs/editor/src/utils/__tests__/freehand.test.js
+++ b/web/libs/editor/src/utils/__tests__/freehand.test.js
@@ -1,0 +1,52 @@
+import { appendFreehandPoint, simplifyFreehandPoints } from "../freehand";
+
+describe("freehand utilities", () => {
+  it("keeps only endpoints for a straight trace", () => {
+    expect(
+      simplifyFreehandPoints(
+        [
+          [0, 0],
+          [1, 0.1],
+          [2, -0.1],
+          [3, 0],
+        ],
+        0.2,
+      ),
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 3, y: 0 },
+    ]);
+  });
+
+  it("preserves corners outside the Douglas-Peucker tolerance", () => {
+    expect(
+      simplifyFreehandPoints(
+        [
+          [0, 0],
+          [5, 0],
+          [5, 5],
+          [10, 5],
+        ],
+        1,
+      ),
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 5, y: 5 },
+      { x: 10, y: 5 },
+    ]);
+  });
+
+  it("filters invalid, duplicate, and too-close samples", () => {
+    const first = appendFreehandPoint([], { x: 1, y: 1 });
+    const unchanged = appendFreehandPoint(first, { x: 1.5, y: 1.5 }, 2);
+    const extended = appendFreehandPoint(unchanged, { x: 4, y: 1 }, 2);
+
+    expect(unchanged).toBe(first);
+    expect(appendFreehandPoint(extended, { x: Number.NaN, y: 1 })).toBe(extended);
+    expect(extended).toEqual([
+      { x: 1, y: 1 },
+      { x: 4, y: 1 },
+    ]);
+  });
+});

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -144,6 +144,9 @@ export const FF_VIDEO_FRAME_SEEK_PRECISION = "fflag_fix_front_optic_1608_improve
  */
 export const FF_FIT_1304_STRICT_OVERLAP = "fflag_feat_all_fit_1304_strict_overlap";
 
+/** Enable press-and-drag freehand drawing for Polygon tools. */
+export const FF_POLYGON_FREEHAND = "fflag_feat_front_polygon_freehand";
+
 Object.assign(window, {
   APP_SETTINGS: {
     ...(window.APP_SETTINGS ?? {}),

--- a/web/libs/editor/src/utils/freehand.js
+++ b/web/libs/editor/src/utils/freehand.js
@@ -1,0 +1,83 @@
+export const FREEHAND_MIN_DISTANCE = 2;
+export const FREEHAND_SIMPLIFY_EPSILON = 2;
+
+const normalizePoint = (point) => {
+  const x = Array.isArray(point) ? point[0] : point?.x;
+  const y = Array.isArray(point) ? point[1] : point?.y;
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return Array.isArray(point) ? { x, y } : { ...point, x, y };
+};
+
+const distanceSquared = (first, second) => {
+  const deltaX = first.x - second.x;
+  const deltaY = first.y - second.y;
+
+  return deltaX * deltaX + deltaY * deltaY;
+};
+
+export function appendFreehandPoint(points, point, minDistance = FREEHAND_MIN_DISTANCE, force = false) {
+  const trace = Array.isArray(points) ? points : [];
+  const nextPoint = normalizePoint(point);
+
+  if (!nextPoint) return trace;
+  if (trace.length === 0) return [nextPoint];
+
+  const pointDistanceSquared = distanceSquared(trace[trace.length - 1], nextPoint);
+  const threshold = Number.isFinite(minDistance) ? Math.max(0, minDistance) : FREEHAND_MIN_DISTANCE;
+
+  if (pointDistanceSquared === 0 || (!force && pointDistanceSquared < threshold * threshold)) return trace;
+  return [...trace, nextPoint];
+}
+
+const pointToSegmentDistanceSquared = (point, start, end) => {
+  const segmentX = end.x - start.x;
+  const segmentY = end.y - start.y;
+  const segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+
+  if (segmentLengthSquared === 0) return distanceSquared(point, start);
+
+  const projection = ((point.x - start.x) * segmentX + (point.y - start.y) * segmentY) / segmentLengthSquared;
+  const ratio = Math.max(0, Math.min(1, projection));
+  return distanceSquared(point, { x: start.x + ratio * segmentX, y: start.y + ratio * segmentY });
+};
+
+const markDouglasPeuckerPoints = (points, firstIndex, lastIndex, epsilonSquared, markers) => {
+  let furthestIndex = -1;
+  let furthestDistanceSquared = epsilonSquared;
+
+  for (let index = firstIndex + 1; index < lastIndex; index++) {
+    const candidate = pointToSegmentDistanceSquared(points[index], points[firstIndex], points[lastIndex]);
+
+    if (candidate > furthestDistanceSquared) {
+      furthestDistanceSquared = candidate;
+      furthestIndex = index;
+    }
+  }
+
+  if (furthestIndex < 0) return;
+  markers[furthestIndex] = 1;
+  markDouglasPeuckerPoints(points, firstIndex, furthestIndex, epsilonSquared, markers);
+  markDouglasPeuckerPoints(points, furthestIndex, lastIndex, epsilonSquared, markers);
+};
+
+export function simplifyFreehandPoints(points, epsilon = FREEHAND_SIMPLIFY_EPSILON) {
+  const trace = (Array.isArray(points) ? points : []).reduce((result, point) => {
+    const normalized = normalizePoint(point);
+
+    if (normalized && (!result.length || distanceSquared(result[result.length - 1], normalized) > 0)) {
+      result.push(normalized);
+    }
+    return result;
+  }, []);
+
+  if (trace.length <= 2) return trace;
+
+  const safeEpsilon = Number.isFinite(epsilon) ? Math.max(0, epsilon) : FREEHAND_SIMPLIFY_EPSILON;
+  const markers = new Uint8Array(trace.length);
+  const lastIndex = trace.length - 1;
+
+  markers[0] = markers[lastIndex] = 1;
+  markDouglasPeuckerPoints(trace, 0, lastIndex, safeEpsilon * safeEpsilon, markers);
+  return trace.filter((_, index) => markers[index] === 1);
+}

--- a/web/libs/editor/src/utils/freehand.js
+++ b/web/libs/editor/src/utils/freehand.js
@@ -1,5 +1,13 @@
 export const FREEHAND_MIN_DISTANCE = 2;
 export const FREEHAND_SIMPLIFY_EPSILON = 2;
+export const FREEHAND_REPAIR_MIN_RAW_POINTS = 8;
+export const FREEHAND_REPAIR_SNAP_RADIUS = 12;
+
+const FREEHAND_REPAIR_ARC_SCORE_TOLERANCE = 1;
+const FREEHAND_REPAIR_POINT_EPSILON = 1e-6;
+const FREEHAND_REPAIR_POINT_EPSILON_SQUARED = FREEHAND_REPAIR_POINT_EPSILON ** 2;
+const FREEHAND_REPAIR_SCORE_SAMPLE_COUNT = 32;
+const FREEHAND_REPAIR_MAX_SIMPLIFIED_POINTS = 2000;
 
 const normalizePoint = (point) => {
   const x = Array.isArray(point) ? point[0] : point?.x;
@@ -80,4 +88,470 @@ export function simplifyFreehandPoints(points, epsilon = FREEHAND_SIMPLIFY_EPSIL
   markers[0] = markers[lastIndex] = 1;
   markDouglasPeuckerPoints(trace, 0, lastIndex, safeEpsilon * safeEpsilon, markers);
   return trace.filter((_, index) => markers[index] === 1);
+}
+
+const normalizeGeometryPoints = (points) => {
+  let values;
+
+  try {
+    values = Array.from(points ?? []);
+  } catch {
+    return null;
+  }
+
+  const normalized = values.map(normalizePoint);
+
+  if (normalized.some((point) => point === null)) return null;
+  return normalized.map(({ x, y }) => ({ x, y }));
+};
+
+const sameGeometryPoint = (first, second) => distanceSquared(first, second) <= FREEHAND_REPAIR_POINT_EPSILON_SQUARED;
+
+const withoutRepeatedClosingPoint = (points) => {
+  if (points.length > 1 && sameGeometryPoint(points[0], points[points.length - 1])) return points.slice(0, -1);
+  return points;
+};
+
+const deduplicateAdjacentGeometryPoints = (points) =>
+  points.reduce((result, point) => {
+    if (!result.length || !sameGeometryPoint(result[result.length - 1], point)) result.push(point);
+    return result;
+  }, []);
+
+const projectPointToSegment = (point, start, end) => {
+  const segmentX = end.x - start.x;
+  const segmentY = end.y - start.y;
+  const segmentLengthSquared = segmentX * segmentX + segmentY * segmentY;
+
+  if (segmentLengthSquared <= FREEHAND_REPAIR_POINT_EPSILON_SQUARED) return null;
+
+  const projection = ((point.x - start.x) * segmentX + (point.y - start.y) * segmentY) / segmentLengthSquared;
+  const t = Math.max(0, Math.min(1, projection));
+  const projectedPoint = { x: start.x + t * segmentX, y: start.y + t * segmentY };
+
+  return {
+    point: projectedPoint,
+    t,
+    distanceSquared: distanceSquared(point, projectedPoint),
+    length: Math.sqrt(segmentLengthSquared),
+  };
+};
+
+const contourMetrics = (contour) => {
+  const lengths = [];
+  const offsets = [0];
+  let perimeter = 0;
+
+  for (let index = 0; index < contour.length; index++) {
+    const length = Math.sqrt(distanceSquared(contour[index], contour[(index + 1) % contour.length]));
+
+    lengths.push(length);
+    perimeter += length;
+    offsets.push(perimeter);
+  }
+
+  return { lengths, offsets, perimeter };
+};
+
+/**
+ * Finds the closest point on a closed contour in the contour's coordinate space.
+ * The returned `position` is segmentIndex + t and can be used to walk the contour
+ * without special-casing the closing segment.
+ */
+export function findNearestContourPoint(rawContour, rawPoint) {
+  const normalizedContour = normalizeGeometryPoints(rawContour);
+  const point = normalizePoint(rawPoint);
+
+  if (!normalizedContour || !point) return null;
+  const contour = withoutRepeatedClosingPoint(normalizedContour);
+
+  if (contour.length < 3) return null;
+
+  const { lengths, offsets, perimeter } = contourMetrics(contour);
+  let nearest = null;
+
+  for (let segmentIndex = 0; segmentIndex < contour.length; segmentIndex++) {
+    const projection = projectPointToSegment(
+      point,
+      contour[segmentIndex],
+      contour[(segmentIndex + 1) % contour.length],
+    );
+
+    if (!projection) continue;
+    if (nearest && projection.distanceSquared >= nearest.distanceSquared) continue;
+
+    nearest = {
+      ...projection,
+      segmentIndex,
+      position: segmentIndex + projection.t,
+      perimeterOffset: offsets[segmentIndex] + projection.t * lengths[segmentIndex],
+    };
+  }
+
+  if (!nearest) return null;
+
+  // Canonicalize vertex projections to the outgoing segment. This gives the same
+  // anchor for either segment incident to a vertex, including the wrap at vertex 0.
+  if (nearest.t <= FREEHAND_REPAIR_POINT_EPSILON) {
+    nearest.t = 0;
+    nearest.point = { ...contour[nearest.segmentIndex] };
+    nearest.position = nearest.segmentIndex;
+    nearest.perimeterOffset = offsets[nearest.segmentIndex];
+  } else if (1 - nearest.t <= FREEHAND_REPAIR_POINT_EPSILON) {
+    nearest.segmentIndex = (nearest.segmentIndex + 1) % contour.length;
+    nearest.t = 0;
+    nearest.point = { ...contour[nearest.segmentIndex] };
+    nearest.position = nearest.segmentIndex;
+    nearest.perimeterOffset = nearest.segmentIndex === 0 ? 0 : offsets[nearest.segmentIndex];
+  }
+
+  nearest.distanceSquared = distanceSquared(point, nearest.point);
+  nearest.distance = Math.sqrt(nearest.distanceSquared);
+  nearest.perimeter = perimeter;
+  delete nearest.length;
+  return nearest;
+}
+
+const crossProduct = (start, end, point) =>
+  (end.x - start.x) * (point.y - start.y) - (end.y - start.y) * (point.x - start.x);
+
+const pointOnSegment = (point, start, end) =>
+  Math.abs(crossProduct(start, end, point)) <= FREEHAND_REPAIR_POINT_EPSILON &&
+  point.x >= Math.min(start.x, end.x) - FREEHAND_REPAIR_POINT_EPSILON &&
+  point.x <= Math.max(start.x, end.x) + FREEHAND_REPAIR_POINT_EPSILON &&
+  point.y >= Math.min(start.y, end.y) - FREEHAND_REPAIR_POINT_EPSILON &&
+  point.y <= Math.max(start.y, end.y) + FREEHAND_REPAIR_POINT_EPSILON;
+
+const segmentsIntersect = (firstStart, firstEnd, secondStart, secondEnd) => {
+  const firstSideStart = crossProduct(firstStart, firstEnd, secondStart);
+  const firstSideEnd = crossProduct(firstStart, firstEnd, secondEnd);
+  const secondSideStart = crossProduct(secondStart, secondEnd, firstStart);
+  const secondSideEnd = crossProduct(secondStart, secondEnd, firstEnd);
+  const opposite = (first, second) =>
+    (first > FREEHAND_REPAIR_POINT_EPSILON && second < -FREEHAND_REPAIR_POINT_EPSILON) ||
+    (first < -FREEHAND_REPAIR_POINT_EPSILON && second > FREEHAND_REPAIR_POINT_EPSILON);
+
+  if (opposite(firstSideStart, firstSideEnd) && opposite(secondSideStart, secondSideEnd)) return true;
+  if (Math.abs(firstSideStart) <= FREEHAND_REPAIR_POINT_EPSILON && pointOnSegment(secondStart, firstStart, firstEnd))
+    return true;
+  if (Math.abs(firstSideEnd) <= FREEHAND_REPAIR_POINT_EPSILON && pointOnSegment(secondEnd, firstStart, firstEnd))
+    return true;
+  if (Math.abs(secondSideStart) <= FREEHAND_REPAIR_POINT_EPSILON && pointOnSegment(firstStart, secondStart, secondEnd))
+    return true;
+  if (Math.abs(secondSideEnd) <= FREEHAND_REPAIR_POINT_EPSILON && pointOnSegment(firstEnd, secondStart, secondEnd))
+    return true;
+  return false;
+};
+
+function intersectsBeyondSharedEndpoint(firstStart, firstEnd, secondStart, secondEnd, sharedPoint) {
+  const firstOther = sameGeometryPoint(firstStart, sharedPoint) ? firstEnd : firstStart;
+  const secondOther = sameGeometryPoint(secondStart, sharedPoint) ? secondEnd : secondStart;
+
+  return pointOnSegment(firstOther, secondStart, secondEnd) || pointOnSegment(secondOther, firstStart, firstEnd);
+}
+
+/**
+ * Checks a closed contour with a sweep-style bounding-box broad phase. `null`
+ * means the comparison budget was exhausted, so callers can fail closed without
+ * risking an unbounded synchronous pause on pathological dense contours.
+ */
+export function hasFreehandContourSelfIntersection(rawPoints, { maxComparisons = 1_000_000 } = {}) {
+  const normalizedPoints = normalizeGeometryPoints(rawPoints);
+
+  if (!normalizedPoints || !Number.isFinite(maxComparisons) || maxComparisons < 0) return null;
+  const points = withoutRepeatedClosingPoint(normalizedPoints);
+
+  if (points.length < 3) return true;
+
+  const segments = points
+    .map((start, index) => {
+      const end = points[(index + 1) % points.length];
+
+      return {
+        index,
+        start,
+        end,
+        minX: Math.min(start.x, end.x),
+        maxX: Math.max(start.x, end.x),
+        minY: Math.min(start.y, end.y),
+        maxY: Math.max(start.y, end.y),
+      };
+    })
+    .sort((first, second) => first.minX - second.minX || first.minY - second.minY);
+
+  let active = [];
+  let comparisons = 0;
+
+  for (const segment of segments) {
+    if (sameGeometryPoint(segment.start, segment.end)) return true;
+    active = active.filter((candidate) => candidate.maxX + FREEHAND_REPAIR_POINT_EPSILON >= segment.minX);
+
+    for (const candidate of active) {
+      comparisons++;
+      if (comparisons > maxComparisons) return null;
+      const indexDistance = Math.abs(candidate.index - segment.index);
+      const adjacent = indexDistance === 1 || indexDistance === points.length - 1;
+
+      if (adjacent) {
+        const sharedPoint = [candidate.start, candidate.end].find(
+          (point) => sameGeometryPoint(point, segment.start) || sameGeometryPoint(point, segment.end),
+        );
+
+        if (
+          !sharedPoint ||
+          intersectsBeyondSharedEndpoint(candidate.start, candidate.end, segment.start, segment.end, sharedPoint)
+        ) {
+          return true;
+        }
+        continue;
+      }
+      if (
+        candidate.maxY + FREEHAND_REPAIR_POINT_EPSILON < segment.minY ||
+        segment.maxY + FREEHAND_REPAIR_POINT_EPSILON < candidate.minY
+      ) {
+        continue;
+      }
+      if (segmentsIntersect(candidate.start, candidate.end, segment.start, segment.end)) return true;
+    }
+    active.push(segment);
+  }
+  return false;
+}
+
+const hasDuplicateGeometryPoints = (points) => {
+  const buckets = new Map();
+
+  for (const point of points) {
+    const cellX = Math.floor(point.x / FREEHAND_REPAIR_POINT_EPSILON);
+    const cellY = Math.floor(point.y / FREEHAND_REPAIR_POINT_EPSILON);
+
+    for (let offsetX = -1; offsetX <= 1; offsetX++) {
+      for (let offsetY = -1; offsetY <= 1; offsetY++) {
+        const nearby = buckets.get(`${cellX + offsetX}:${cellY + offsetY}`);
+
+        if (nearby?.some((candidate) => sameGeometryPoint(point, candidate))) return true;
+      }
+    }
+    const key = `${cellX}:${cellY}`;
+
+    buckets.set(key, [...(buckets.get(key) ?? []), point]);
+  }
+  return false;
+};
+
+const hasSelfIntersection = (points, closed) => {
+  const segmentCount = closed ? points.length : points.length - 1;
+
+  for (let first = 0; first < segmentCount; first++) {
+    const firstStart = points[first];
+    const firstEnd = points[(first + 1) % points.length];
+
+    if (sameGeometryPoint(firstStart, firstEnd)) return true;
+
+    for (let second = first + 1; second < segmentCount; second++) {
+      const adjacent = second === first + 1 || (closed && first === 0 && second === segmentCount - 1);
+
+      if (adjacent) continue;
+      if (segmentsIntersect(firstStart, firstEnd, points[second], points[(second + 1) % points.length])) return true;
+    }
+  }
+  return false;
+};
+
+const signedDoubleArea = (points) =>
+  points.reduce((area, point, index) => {
+    const next = points[(index + 1) % points.length];
+    return area + point.x * next.y - next.x * point.y;
+  }, 0);
+
+const isValidClosedContour = (points) =>
+  points.length >= 3 &&
+  !hasDuplicateGeometryPoints(points) &&
+  Math.abs(signedDoubleArea(points)) > FREEHAND_REPAIR_POINT_EPSILON;
+
+export function isValidFreehandContour(rawPoints, options) {
+  const normalizedPoints = normalizeGeometryPoints(rawPoints);
+
+  if (!normalizedPoints) return false;
+  const points = withoutRepeatedClosingPoint(normalizedPoints);
+
+  return isValidClosedContour(points) && hasFreehandContourSelfIntersection(points, options) === false;
+}
+
+const replacementIntersectsRetainedArc = (replacement, retainedArc) => {
+  const replacementLastSegment = replacement.length - 2;
+  const retainedLastSegment = retainedArc.length - 2;
+
+  for (let replacementIndex = 0; replacementIndex <= replacementLastSegment; replacementIndex++) {
+    const replacementStart = replacement[replacementIndex];
+    const replacementEnd = replacement[replacementIndex + 1];
+
+    for (let retainedIndex = 0; retainedIndex <= retainedLastSegment; retainedIndex++) {
+      const retainedStart = retainedArc[retainedIndex];
+      const retainedEnd = retainedArc[retainedIndex + 1];
+
+      if (!segmentsIntersect(replacementStart, replacementEnd, retainedStart, retainedEnd)) continue;
+
+      const sharedPoint =
+        replacementIndex === 0 && retainedIndex === retainedLastSegment
+          ? replacementStart
+          : replacementIndex === replacementLastSegment && retainedIndex === 0
+            ? replacementEnd
+            : null;
+
+      if (
+        !sharedPoint ||
+        intersectsBeyondSharedEndpoint(replacementStart, replacementEnd, retainedStart, retainedEnd, sharedPoint)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const buildForwardContourArc = (contour, startAnchor, endAnchor) => {
+  let endPosition = endAnchor.position;
+
+  if (endPosition <= startAnchor.position) endPosition += contour.length;
+  const points = [startAnchor.point];
+
+  for (let vertex = Math.floor(startAnchor.position) + 1; vertex < endPosition; vertex++) {
+    points.push(contour[vertex % contour.length]);
+  }
+  points.push(endAnchor.point);
+  return deduplicateAdjacentGeometryPoints(points);
+};
+
+const polylineLength = (points) => {
+  let length = 0;
+
+  for (let index = 1; index < points.length; index++) {
+    length += Math.sqrt(distanceSquared(points[index - 1], points[index]));
+  }
+  return length;
+};
+
+const resamplePolyline = (points, sampleCount) => {
+  const segmentLengths = [];
+  const offsets = [0];
+  let length = 0;
+
+  for (let index = 1; index < points.length; index++) {
+    const segmentLength = Math.sqrt(distanceSquared(points[index - 1], points[index]));
+
+    segmentLengths.push(segmentLength);
+    length += segmentLength;
+    offsets.push(length);
+  }
+
+  if (length <= FREEHAND_REPAIR_POINT_EPSILON) return null;
+
+  const samples = [];
+  let segmentIndex = 0;
+
+  for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+    const targetOffset = (length * sampleIndex) / (sampleCount - 1);
+
+    while (segmentIndex < segmentLengths.length - 1 && offsets[segmentIndex + 1] < targetOffset) {
+      segmentIndex++;
+    }
+
+    const segmentLength = segmentLengths[segmentIndex];
+    const ratio = segmentLength > 0 ? (targetOffset - offsets[segmentIndex]) / segmentLength : 0;
+    const start = points[segmentIndex];
+    const end = points[segmentIndex + 1];
+
+    samples.push({
+      x: start.x + (end.x - start.x) * ratio,
+      y: start.y + (end.y - start.y) * ratio,
+    });
+  }
+  return samples;
+};
+
+const traceToArcProximity = (trace, arc) => {
+  const traceSamples = resamplePolyline(trace, FREEHAND_REPAIR_SCORE_SAMPLE_COUNT);
+  const arcSamples = resamplePolyline(arc, FREEHAND_REPAIR_SCORE_SAMPLE_COUNT);
+
+  if (!traceSamples || !arcSamples) return Number.POSITIVE_INFINITY;
+  return (
+    traceSamples.reduce(
+      (score, tracePoint, index) => score + Math.sqrt(distanceSquared(tracePoint, arcSamples[index])),
+      0,
+    ) / traceSamples.length
+  );
+};
+
+const chooseReplacementArc = (trace, forwardArc, backwardArc) => {
+  const forwardScore = traceToArcProximity(trace, forwardArc);
+  const backwardScore = traceToArcProximity(trace, backwardArc);
+  const scoreDifference = Math.abs(forwardScore - backwardScore);
+
+  if (!Number.isFinite(forwardScore) || !Number.isFinite(backwardScore)) return null;
+  if (scoreDifference > FREEHAND_REPAIR_ARC_SCORE_TOLERANCE) {
+    return forwardScore < backwardScore ? "forward" : "backward";
+  }
+
+  const forwardLength = polylineLength(forwardArc);
+  const backwardLength = polylineLength(backwardArc);
+
+  if (Math.abs(forwardLength - backwardLength) <= FREEHAND_REPAIR_POINT_EPSILON) return null;
+  return forwardLength < backwardLength ? "forward" : "backward";
+};
+
+/**
+ * Replaces one arc of a closed canvas-space contour with a canvas-space freehand
+ * trace. Both trace endpoints are snapped to the contour. Ambiguous or invalid
+ * repairs fail closed by returning null.
+ */
+export function buildFreehandRepairContour(rawContour, rawTrace, options = {}) {
+  const normalizedContour = normalizeGeometryPoints(rawContour);
+  const normalizedTrace = normalizeGeometryPoints(rawTrace);
+  const snapRadius = options?.snapRadius ?? FREEHAND_REPAIR_SNAP_RADIUS;
+
+  if (!normalizedContour || !normalizedTrace || !Number.isFinite(snapRadius) || snapRadius < 0) return null;
+
+  const contour = withoutRepeatedClosingPoint(normalizedContour);
+  const trace = deduplicateAdjacentGeometryPoints(normalizedTrace);
+
+  if (!isValidFreehandContour(contour) || trace.length < 2 || trace.length > FREEHAND_REPAIR_MAX_SIMPLIFIED_POINTS) {
+    return null;
+  }
+  if (hasDuplicateGeometryPoints(trace) || hasSelfIntersection(trace, false)) return null;
+
+  const startAnchor = findNearestContourPoint(contour, trace[0]);
+  const endAnchor = findNearestContourPoint(contour, trace[trace.length - 1]);
+
+  if (!startAnchor || !endAnchor) return null;
+  if (startAnchor.distance > snapRadius || endAnchor.distance > snapRadius) return null;
+  if (sameGeometryPoint(startAnchor.point, endAnchor.point)) return null;
+
+  const snappedTrace = deduplicateAdjacentGeometryPoints([startAnchor.point, ...trace.slice(1, -1), endAnchor.point]);
+
+  if (snappedTrace.length < 2 || hasDuplicateGeometryPoints(snappedTrace) || hasSelfIntersection(snappedTrace, false))
+    return null;
+
+  const forwardArc = buildForwardContourArc(contour, startAnchor, endAnchor);
+  const backwardArc = [...buildForwardContourArc(contour, endAnchor, startAnchor)].reverse();
+  const replacedArc = chooseReplacementArc(snappedTrace, forwardArc, backwardArc);
+
+  if (!replacedArc) return null;
+
+  const retainedArc = replacedArc === "forward" ? buildForwardContourArc(contour, endAnchor, startAnchor) : forwardArc;
+  const replacement = replacedArc === "forward" ? snappedTrace : [...snappedTrace].reverse();
+
+  if (replacementIntersectsRetainedArc(replacement, retainedArc)) return null;
+
+  const repairedPoints = deduplicateAdjacentGeometryPoints(
+    replacedArc === "forward"
+      ? [...replacement, ...retainedArc.slice(1, -1)]
+      : [...retainedArc, ...replacement.slice(1, -1)],
+  );
+  const points = withoutRepeatedClosingPoint(repairedPoints);
+
+  if (!isValidFreehandContour(points)) return null;
+  if (Math.sign(signedDoubleArea(points)) !== Math.sign(signedDoubleArea(contour))) return null;
+
+  return { points, replacedArc, startAnchor, endAnchor };
 }

--- a/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
@@ -1,0 +1,76 @@
+import { Hotkeys, ImageView, LabelStudio, Sidebar } from "@humansignal/frontend-test/helpers/LSF";
+import { FF_POLYGON_FREEHAND } from "../../../../src/utils/feature-flags";
+import { imageData, imageToolsConfig } from "../../data/image_segmentation/stage_interactions";
+
+const drawFreehand = (pointerType = "mouse") => {
+  ImageView.drawingArea.then(($element) => {
+    const { width, height } = $element[0].getBoundingClientRect();
+    const points = [
+      [width * 0.2, height * 0.2],
+      [width * 0.7, height * 0.2],
+      [width * 0.7, height * 0.7],
+      [width * 0.2, height * 0.7],
+    ];
+    const pointer = { eventConstructor: "PointerEvent", pointerId: 1, pointerType, isPrimary: true };
+
+    cy.wrap($element)
+      .trigger("pointerdown", points[0][0], points[0][1], { ...pointer, button: 0, buttons: 1 })
+      .trigger("pointermove", points[1][0], points[1][1], { ...pointer, buttons: 1 })
+      .trigger("pointermove", points[2][0], points[2][1], { ...pointer, buttons: 1 })
+      .trigger("pointermove", points[3][0], points[3][1], { ...pointer, buttons: 1 })
+      .trigger("pointerup", points[3][0], points[3][1], { ...pointer, button: 0, buttons: 0 });
+  });
+};
+
+const drawClickPolygon = () => {
+  ImageView.drawPolygonRelative(
+    [
+      [0.2, 0.2],
+      [0.7, 0.2],
+      [0.7, 0.7],
+      [0.2, 0.7],
+    ],
+    true,
+  );
+};
+
+describe("Freehand Polygon", () => {
+  it("ignores pointer drags while the feature flag is off", () => {
+    LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: false });
+    LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
+    LabelStudio.waitForImageReady();
+    ImageView.selectPolygonToolByButton();
+
+    drawFreehand();
+
+    Sidebar.hasNoRegions();
+  });
+
+  [false, true].forEach((freehandEnabled) => {
+    it(`preserves click-to-place drawing while the feature flag is ${freehandEnabled ? "on" : "off"}`, () => {
+      LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: freehandEnabled });
+      LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
+      LabelStudio.waitForImageReady();
+      ImageView.selectPolygonToolByButton();
+
+      drawClickPolygon();
+
+      Sidebar.hasRegions(1);
+    });
+  });
+
+  ["mouse", "pen", "touch"].forEach((pointerType) => {
+    it(`draws one undoable contour with ${pointerType} input`, () => {
+      LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: true });
+      LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
+      LabelStudio.waitForImageReady();
+      ImageView.selectPolygonToolByButton();
+
+      drawFreehand(pointerType);
+
+      Sidebar.hasRegions(1);
+      Hotkeys.undo();
+      Sidebar.hasNoRegions();
+    });
+  });
+});

--- a/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
@@ -1,5 +1,5 @@
 import { Hotkeys, ImageView, LabelStudio, Sidebar } from "@humansignal/frontend-test/helpers/LSF";
-import { FF_POLYGON_FREEHAND } from "../../../../src/utils/feature-flags";
+import { FF_DEV_1442, FF_POLYGON_FREEHAND } from "../../../../src/utils/feature-flags";
 import { imageData, imageToolsConfig } from "../../data/image_segmentation/stage_interactions";
 
 const drawFreehand = (pointerType = "mouse", includeCompatibilityMouseEvents = false) => {
@@ -51,6 +51,52 @@ const drawClickPolygon = () => {
   );
 };
 
+const repairSelectedPolygon = (includeCompatibilityMouseEvents = false) => {
+  ImageView.drawingArea.then(($element) => {
+    const { width, height } = $element[0].getBoundingClientRect();
+    const points = [
+      [width * 0.3, height * 0.2],
+      [width * 0.34, height * 0.17],
+      [width * 0.38, height * 0.15],
+      [width * 0.42, height * 0.14],
+      [width * 0.46, height * 0.13],
+      [width * 0.5, height * 0.14],
+      [width * 0.54, height * 0.15],
+      [width * 0.57, height * 0.17],
+      [width * 0.6, height * 0.2],
+    ];
+    const pointer = { eventConstructor: "PointerEvent", pointerId: 2, pointerType: "mouse", isPrimary: true };
+    let interaction = cy
+      .wrap($element)
+      .trigger("pointerdown", points[0][0], points[0][1], { ...pointer, button: 0, buttons: 1 });
+
+    if (includeCompatibilityMouseEvents) {
+      interaction = interaction.trigger("mousedown", points[0][0], points[0][1], { button: 0, buttons: 1 });
+    }
+
+    points.slice(1, -1).forEach(([x, y]) => {
+      interaction = interaction.trigger("pointermove", x, y, { ...pointer, buttons: 1 });
+      if (includeCompatibilityMouseEvents) interaction = interaction.trigger("mousemove", x, y, { buttons: 1 });
+    });
+    interaction = interaction.trigger("pointerup", points[points.length - 1][0], points[points.length - 1][1], {
+      ...pointer,
+      button: 0,
+      buttons: 0,
+    });
+    if (includeCompatibilityMouseEvents) {
+      interaction
+        .trigger("mouseup", points[points.length - 1][0], points[points.length - 1][1], {
+          button: 0,
+          buttons: 0,
+        })
+        .trigger("click", points[points.length - 1][0], points[points.length - 1][1], {
+          button: 0,
+          buttons: 0,
+        });
+    }
+  });
+};
+
 describe("Freehand Polygon", () => {
   it("ignores pointer drags while the feature flag is off", () => {
     LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: false });
@@ -91,16 +137,65 @@ describe("Freehand Polygon", () => {
     });
   });
 
-  it("creates only one contour when the browser emits compatibility mouse events", () => {
+  [false, true].forEach((deferredClickEnabled) => {
+    it(`creates only one contour with compatibility mouse events and deferred click ${
+      deferredClickEnabled ? "enabled" : "disabled"
+    }`, () => {
+      LabelStudio.addFeatureFlagsOnPageLoad({
+        [FF_POLYGON_FREEHAND]: true,
+        [FF_DEV_1442]: deferredClickEnabled,
+      });
+      LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
+      LabelStudio.waitForImageReady();
+      ImageView.selectPolygonToolByButton();
+
+      drawFreehand("mouse", true);
+
+      Sidebar.hasRegions(1);
+      Hotkeys.undo();
+      Sidebar.hasNoRegions();
+    });
+  });
+
+  it("repairs a selected contour in one undoable edit without replacing the region", () => {
     LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: true });
     LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
     LabelStudio.waitForImageReady();
     ImageView.selectPolygonToolByButton();
-
-    drawFreehand("mouse", true);
-
+    drawClickPolygon();
     Sidebar.hasRegions(1);
-    Hotkeys.undo();
-    Sidebar.hasNoRegions();
+
+    ImageView.clickAtRelative(0.45, 0.45);
+    Sidebar.hasSelectedRegions(1);
+
+    LabelStudio.serialize().then((beforeResult) => {
+      const before = beforeResult[0];
+      const beforePoints = before.value.points.map((point) => [...point]);
+
+      repairSelectedPolygon(true);
+      Sidebar.hasRegions(1);
+
+      LabelStudio.serialize().then((afterResult) => {
+        const after = afterResult[0];
+        const afterPoints = after.value.points.map((point) => [...point]);
+
+        expect(after.id).to.equal(before.id);
+        expect(afterPoints).not.to.deep.equal(beforePoints);
+
+        Hotkeys.undo();
+        Sidebar.hasRegions(1);
+        LabelStudio.serialize().then((undoResult) => {
+          expect(undoResult[0].id).to.equal(before.id);
+          expect(undoResult[0].value.points).to.deep.equal(beforePoints);
+        });
+
+        Hotkeys.redo();
+        Sidebar.hasRegions(1);
+        LabelStudio.serialize().then((redoResult) => {
+          expect(redoResult[0].id).to.equal(before.id);
+          expect(redoResult[0].value.points).to.deep.equal(afterPoints);
+        });
+      });
+    });
   });
 });

--- a/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
@@ -55,15 +55,15 @@ const repairSelectedPolygon = (includeCompatibilityMouseEvents = false) => {
   ImageView.drawingArea.then(($element) => {
     const { width, height } = $element[0].getBoundingClientRect();
     const points = [
-      [width * 0.3, height * 0.2],
-      [width * 0.34, height * 0.17],
-      [width * 0.38, height * 0.15],
-      [width * 0.42, height * 0.14],
-      [width * 0.46, height * 0.13],
-      [width * 0.5, height * 0.14],
-      [width * 0.54, height * 0.15],
-      [width * 0.57, height * 0.17],
-      [width * 0.6, height * 0.2],
+      [width * 0.2, height * 0.2],
+      [width * 0.26, height * 0.16],
+      [width * 0.32, height * 0.13],
+      [width * 0.38, height * 0.11],
+      [width * 0.45, height * 0.1],
+      [width * 0.52, height * 0.11],
+      [width * 0.59, height * 0.13],
+      [width * 0.65, height * 0.16],
+      [width * 0.7, height * 0.2],
     ];
     const pointer = { eventConstructor: "PointerEvent", pointerId: 2, pointerType: "mouse", isPrimary: true };
     let interaction = cy
@@ -167,6 +167,17 @@ describe("Freehand Polygon", () => {
 
     ImageView.clickAtRelative(0.45, 0.45);
     Sidebar.hasSelectedRegions(1);
+    ImageView.toolBar.find('[aria-label="polygon-tool"]').should("have.class", "lsf-tool_active");
+    cy.window().then((win) => {
+      const annotation = win.Htx.annotationStore.selected;
+      const image = annotation.objects.find((object) => object.type === "image");
+      const tool = image.getToolsManager().findSelectedTool();
+      const region = annotation.selectedRegions[0];
+
+      expect(tool.toolName).to.equal("PolygonTool");
+      expect(annotation.selectedRegions).to.have.length(1);
+      expect(tool.canRepairFreehand(region), "repair eligible").to.equal(true);
+    });
 
     LabelStudio.serialize().then((beforeResult) => {
       const before = beforeResult[0];
@@ -178,9 +189,16 @@ describe("Freehand Polygon", () => {
       LabelStudio.serialize().then((afterResult) => {
         const after = afterResult[0];
         const afterPoints = after.value.points.map((point) => [...point]);
+        const retainedBottomVertices = beforePoints
+          .slice(2)
+          .every(([x, y]) =>
+            afterPoints.some(([afterX, afterY]) => Math.abs(afterX - x) < 1e-6 && Math.abs(afterY - y) < 1e-6),
+          );
 
         expect(after.id).to.equal(before.id);
         expect(afterPoints).not.to.deep.equal(beforePoints);
+        expect(afterPoints.length).to.be.greaterThan(beforePoints.length);
+        expect(retainedBottomVertices).to.equal(true);
 
         Hotkeys.undo();
         Sidebar.hasRegions(1);

--- a/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
+++ b/web/libs/editor/tests/integration/e2e/image_segmentation/freehand_polygon.cy.ts
@@ -2,7 +2,7 @@ import { Hotkeys, ImageView, LabelStudio, Sidebar } from "@humansignal/frontend-
 import { FF_POLYGON_FREEHAND } from "../../../../src/utils/feature-flags";
 import { imageData, imageToolsConfig } from "../../data/image_segmentation/stage_interactions";
 
-const drawFreehand = (pointerType = "mouse") => {
+const drawFreehand = (pointerType = "mouse", includeCompatibilityMouseEvents = false) => {
   ImageView.drawingArea.then(($element) => {
     const { width, height } = $element[0].getBoundingClientRect();
     const points = [
@@ -13,12 +13,29 @@ const drawFreehand = (pointerType = "mouse") => {
     ];
     const pointer = { eventConstructor: "PointerEvent", pointerId: 1, pointerType, isPrimary: true };
 
-    cy.wrap($element)
-      .trigger("pointerdown", points[0][0], points[0][1], { ...pointer, button: 0, buttons: 1 })
-      .trigger("pointermove", points[1][0], points[1][1], { ...pointer, buttons: 1 })
-      .trigger("pointermove", points[2][0], points[2][1], { ...pointer, buttons: 1 })
-      .trigger("pointermove", points[3][0], points[3][1], { ...pointer, buttons: 1 })
-      .trigger("pointerup", points[3][0], points[3][1], { ...pointer, button: 0, buttons: 0 });
+    let interaction = cy
+      .wrap($element)
+      .trigger("pointerdown", points[0][0], points[0][1], { ...pointer, button: 0, buttons: 1 });
+
+    if (includeCompatibilityMouseEvents) {
+      interaction = interaction.trigger("mousedown", points[0][0], points[0][1], { button: 0, buttons: 1 });
+    }
+
+    points.slice(1).forEach(([x, y]) => {
+      interaction = interaction.trigger("pointermove", x, y, { ...pointer, buttons: 1 });
+      if (includeCompatibilityMouseEvents) interaction = interaction.trigger("mousemove", x, y, { buttons: 1 });
+    });
+
+    interaction = interaction.trigger("pointerup", points[3][0], points[3][1], {
+      ...pointer,
+      button: 0,
+      buttons: 0,
+    });
+    if (includeCompatibilityMouseEvents) {
+      interaction
+        .trigger("mouseup", points[3][0], points[3][1], { button: 0, buttons: 0 })
+        .trigger("click", points[3][0], points[3][1], { button: 0, buttons: 0 });
+    }
   });
 };
 
@@ -72,5 +89,18 @@ describe("Freehand Polygon", () => {
       Hotkeys.undo();
       Sidebar.hasNoRegions();
     });
+  });
+
+  it("creates only one contour when the browser emits compatibility mouse events", () => {
+    LabelStudio.addFeatureFlagsOnPageLoad({ [FF_POLYGON_FREEHAND]: true });
+    LabelStudio.params().config(imageToolsConfig).data(imageData).withResult([]).init();
+    LabelStudio.waitForImageReady();
+    ImageView.selectPolygonToolByButton();
+
+    drawFreehand("mouse", true);
+
+    Sidebar.hasRegions(1);
+    Hotkeys.undo();
+    Sidebar.hasNoRegions();
   });
 });


### PR DESCRIPTION
## Problem

The accepted community PRD in #8315 describes the current limitation:

> Drawing polygons by clicking with the mouse for every point of the polygon is less optimal compared to simply being able to draw a polygon by holding down the mouse. Also the clicking technique does not work well with touchscreen devices or drawing pens, because the hovering feature is not easily available to these devices.

## Solution

- Add a pointer-events drawing path for primary mouse, pen, and touch input.
- Simplify sampled points with a small in-house Ramer-Douglas-Peucker implementation.
- Convert coordinates at sample time while keeping simplification in zoom-independent screen space.
- Require a deliberate 5-pixel displacement before freehand semantics suppress compatibility mouse events.
- Reuse the stock canvas target checks so existing regions, anchors, transformers, and read-only annotations keep their normal interactions.
- Preserve the existing Cmd/Ctrl override for intentionally drawing over another region.
- Scope touch-action suppression to the selected Polygon tool.
- Commit each completed contour as one undoable history action.
- Release the history transaction safely when completion is cancelled by a tool switch or teardown.
- Guard the behavior with `fflag_feat_front_polygon_freehand`, default off.
- Preserve the existing click-to-place Polygon workflow with the flag both off and on.
- Add no runtime or development dependencies.

## User Stories

- As an annotator, I want to draw polygons by simply dragging the mouse, so that I can annotate faster.
- As an annotator, I want to draw polygons via touchscreen or pen devices, so that I can annotate faster and more comfortably.

## Acceptance Criteria

1. Given `fflag_feat_front_polygon_freehand` is disabled, when an annotator uses the Polygon tool, then the existing click-to-place workflow is unchanged and a pointer drag does not create a contour.
2. Given the flag is enabled and the Polygon tool is active, when an annotator presses, drags through at least three distinct points, and releases with a primary mouse pointer, then one simplified polygon is created.
3. Repeat criterion 2 with a pen, then with primary touch; each input creates exactly one polygon.
4. Given the flag is either enabled or disabled, click four vertices and close the polygon; exactly one stock click-to-place polygon is created.
5. Given a pointer moves less than 5 pixels before release, the gesture continues through the stock click path and creates no freehand contour.
6. If the stage transform changes during a drag, each committed vertex retains the coordinate transform active when that sample was collected.
7. After any completed freehand contour, one Undo action removes the whole contour and one Redo action restores it.
8. If the active pointer is cancelled, leaves the stage in a capture-less environment, the tool changes, or the component unmounts, then the in-progress trace is discarded without leaving drawing or history state stuck.
9. A freehand trace produces no additional network request and requires no new package.

## Testing

- `yarn lsf:unit --runInBand --silent`: 129 test suites passed; 3,331 tests passed and 5 were skipped.
- `yarn lsf:unit --runInBand --silent --testPathPatterns='components/ImageView/__tests__/ImageView.test.jsx|tools/__tests__/Polygon.test.js|utils/__tests__/freehand.test.js'`: 3 suites and 85 tests passed.
- `BABEL_ENV=test MODE=standalone yarn nx run editor:build:production --skip-nx-cache`: production build compiled successfully.
- Added Cypress coverage for flag-off drag behavior, click-to-place coexistence with the flag off and on, mouse, pen, touch, compatibility mouse events, and single-undo behavior.
- The integration spec passes locally on macOS with Cypress 14.5.0 and Electron against the production standalone build: all 7 tests passing.
- Regression coverage verifies that freehand does not start from existing regions, transformer anchors, or read-only annotations, while the Cmd/Ctrl override remains available.

## Credit and context

Thank you to @cozeybozey for the PRD and proof of concept in #8315 and the earlier exploration in #8388. This implementation is intentionally scoped to the generic freehand Polygon workflow and uses pointer events plus an in-house simplifier without the extra dependency or unrelated changes from the prior attempt.

The interaction model has been production-tested with a medical imaging annotation team using tablets and styluses.

Closes-PRD: #8315
