### PR TITLE
fix: avoid DB access during app initialization in labels_manager seri…

### DIFF
--- a/label_studio/labels_manager/serializers.py
+++ b/label_studio/labels_manager/serializers.py
@@ -88,7 +88,7 @@ class LabelListSerializer(serializers.ListSerializer):
 class LabelCreateSerializer(serializers.ModelSerializer):
     created_by = serializers.PrimaryKeyRelatedField(required=False, read_only=True)
     organization = serializers.PrimaryKeyRelatedField(required=False, read_only=True)
-    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
+    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects)
     from_name = serializers.CharField()
 
     class Meta:
@@ -116,6 +116,6 @@ class LabelSerializer(FlexFieldsModelSerializer):
 
 
 class LabelBulkUpdateSerializer(serializers.Serializer):
-    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all(), required=False, default=None)
+    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects, required=False, default=None)
     old_label = serializers.JSONField()
     new_label = serializers.JSONField()


### PR DESCRIPTION
## Description

Fixes the RuntimeWarning reported in issue #9715, where Django 5.1 emitted
"Accessing the database during app initialization is discouraged" on server startup.

Fixes #9715

## Root Cause

In `labels_manager/serializers.py`, two `PrimaryKeyRelatedField` fields were
declared with `queryset=Project.objects.all()` at class level. Since class
attributes are evaluated at import time, which happens during
`AppConfig.ready()`, this triggered a SQL query before the database was
ready, violating Django 5.1's expected app lifecycle.


## Fix

Replaced the eager QuerySet with a lazy Manager in both occurrences:

```python
# Before
project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())

# After
project = serializers.PrimaryKeyRelatedField(queryset=Project.objects)
```

DRF accepts both QuerySet and Manager in `PrimaryKeyRelatedField`. When given
a Manager, it calls `get_queryset()` internally only at request validation
time, eliminating the database access during app initialization.

## Testing

Server started with `python -W error::RuntimeWarning manage.py runserver`, 
no RuntimeWarning emitted after the fix.