### PR TITLE
fix: optimize project queue total count

### DIFF
--- a/label_studio/projects/serializers.py
+++ b/label_studio/projects/serializers.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import bleach
 from constants import SAFE_HTML_ATTRIBUTES, SAFE_HTML_TAGS
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from fsm.serializer_fields import FSMStateField
 from label_studio_sdk.label_interface import LabelInterface
@@ -35,7 +35,7 @@ from projects.models import Project, ProjectImport, ProjectOnboarding, ProjectRe
 from rest_flex_fields import FlexFieldsModelSerializer
 from rest_framework import serializers
 from rest_framework.serializers import SerializerMethodField
-from tasks.models import Task
+from tasks.models import Annotation, Task
 from users.serializers import UserSimpleSerializer
 
 
@@ -350,10 +350,8 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         return super().update(instance, validated_data)
 
     def get_queue_total(self, project) -> int:
-        remain = project.tasks.filter(
-            Q(is_labeled=False) & ~Q(annotations__completed_by_id=self.user_id)
-            | Q(annotations__completed_by_id=self.user_id)
-        ).distinct()
+        user_annotations = Annotation.objects.filter(task_id=OuterRef('pk'), completed_by_id=self.user_id)
+        remain = project.tasks.filter(Q(is_labeled=False) | Exists(user_annotations))
         return remain.count()
 
     def get_queue_done(self, project) -> int:

--- a/label_studio/projects/tests/test_serializers.py
+++ b/label_studio/projects/tests/test_serializers.py
@@ -1,9 +1,14 @@
-"""Tests for projects.serializers (control_weights validation)."""
+"""Tests for project serializers."""
 
 import pytest
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from projects.serializers import ControlTagWeightSerializer, ProjectSerializer
+from projects.tests.factories import ProjectFactory
 from rest_framework.exceptions import ValidationError
+from tasks.tests.factories import AnnotationFactory, TaskFactory
+from users.tests.factories import UserFactory
 
 
 class TestControlTagWeightSerializer(TestCase):
@@ -84,7 +89,7 @@ class TestControlTagWeightSerializer(TestCase):
 
 
 class TestProjectSerializer(TestCase):
-    """Validates the cross-field validate_control_weights on ProjectSerializer."""
+    """Validates project serializer behavior, including weights and queue counts."""
 
     def _validate(self, value):
         """Run validate_control_weights from a ProjectSerializer instance."""
@@ -124,3 +129,30 @@ class TestProjectSerializer(TestCase):
     def test_accepts_empty_dict(self):
         """Empty dict passes through unchanged."""
         assert self._validate({}) == {}
+
+    def test_queue_total_uses_correlated_user_annotation_lookup(self):
+        project = ProjectFactory()
+        current_user = project.created_by
+        other_user = UserFactory()
+        TaskFactory(project=project, is_labeled=False)
+        current_user_task = TaskFactory(project=project, is_labeled=True)
+        other_user_task = TaskFactory(project=project, is_labeled=True)
+        unlabeled_other_user_task = TaskFactory(project=project, is_labeled=False)
+        mixed_user_task = TaskFactory(project=project, is_labeled=True)
+        AnnotationFactory(task=current_user_task, completed_by=current_user)
+        AnnotationFactory(task=other_user_task, completed_by=other_user)
+        AnnotationFactory(task=unlabeled_other_user_task, completed_by=other_user)
+        AnnotationFactory(task=mixed_user_task, completed_by=other_user)
+        AnnotationFactory(task=mixed_user_task, completed_by=current_user)
+        project.tasks.filter(pk__in=[current_user_task.pk, other_user_task.pk, mixed_user_task.pk]).update(
+            is_labeled=True
+        )
+        serializer = ProjectSerializer(context={'user_cache': {current_user.id: current_user}})
+
+        with CaptureQueriesContext(connection) as captured_queries:
+            queue_total = serializer.get_queue_total(project)
+
+        assert len(captured_queries) == 1
+        assert queue_total == 4, captured_queries[0]['sql']
+        assert 'EXISTS' in captured_queries[0]['sql']
+        assert 'DISTINCT' not in captured_queries[0]['sql']


### PR DESCRIPTION
## Reason for change

`ProjectSerializer.get_queue_total` currently combines a negated annotation relation, a positive annotation relation, and `distinct().count()`. Django compiles that to a duplicate-producing outer join plus an anti-subquery and `DISTINCT`. This PR expresses the same membership rule directly as `unlabeled OR EXISTS(current-user annotation)`.

Fixes #9861.

## Performance evidence

Read-only PostgreSQL A/B tests on three representative project/user pairs preserved exact counts and reduced server execution time:

- 268.2 ms -> 16.3 ms
- 31.5 ms -> 9.5 ms
- 35.9 ms -> 7.5 ms

The PostgreSQL ORM SQL for the candidate uses one correlated `EXISTS`, with no outer annotation join or `DISTINCT`.

## Testing

- `projects/tests/test_serializers.py`: 17 passed on SQLite
- Ruff check and format: passed
- Regression matrix covers unlabeled tasks, current-user annotations, other-user annotations, and mixed annotations
- Test asserts one count query, `EXISTS` present, and `DISTINCT` absent
- Live PostgreSQL exact-result parity verified for all three A/B cases

## Acceptance criteria

- Exact task-membership parity with the existing predicate
- One count query
- Correlated `EXISTS`; no outer annotation join or `DISTINCT`
- SQLite and PostgreSQL-compatible ORM query

## Rollout and risk

No schema or API contract change is involved. The risk is limited to task-membership equivalence; the regression matrix and live exact-result comparisons cover that boundary. No feature flag is needed.