### PR TITLE
fix: restore grpcio-reflection test dep for python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ test = [
     "pytest-mock==3.15.1",
     "tavern==3.3.3; python_version >= '3.11'",
     "tavern==2.17.0; python_version < '3.11'",
+    # tavern 2.x (py3.10) unconditionally loads its grpc plugin because grpcio is
+    # present transitively; without grpc_reflection every tavern test errors at setup
+    "grpcio-reflection==1.78.0 ; python_full_version < '3.11'",
     "fakeredis~=2.26.1",
     "pytest-env==1.6.0; python_version >= '3.11'",
     "pytest-env==0.6.2; python_version < '3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-03T15:52:00.261625377Z"
+exclude-newer = "2026-08-03T16:34:03.034629Z"
 exclude-newer-span = "P4D"
 
 [[package]]
@@ -1275,6 +1275,19 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio-reflection"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/06/337546aae558675f79cae2a8c1ce0c9b1952cbc5c28b01878f68d040f5bb/grpcio_reflection-1.78.0.tar.gz", hash = "sha256:e6e60c0b85dbcdf963b4d4d150c0f1d238ba891d805b575c52c0365d07fc0c40", size = 19098, upload-time = "2026-02-06T10:01:52.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/6d/4d095d27ccd049865ecdafc467754e9e47ad0f677a30dda969c3590f6582/grpcio_reflection-1.78.0-py3-none-any.whl", hash = "sha256:06fcfde9e6888cdd12e9dd1cf6dc7c440c2e9acf420f696ccbe008672ed05b60", size = 22800, upload-time = "2026-02-06T10:01:33.822Z" },
+]
+
+[[package]]
 name = "grpcio-status"
 version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1817,6 +1830,7 @@ test = [
     { name = "factory-boy" },
     { name = "fakeredis" },
     { name = "freezegun" },
+    { name = "grpcio-reflection", marker = "python_full_version < '3.11'" },
     { name = "mock" },
     { name = "moto" },
     { name = "pre-commit" },
@@ -1910,6 +1924,7 @@ test = [
     { name = "factory-boy", specifier = ">=3.3.3,<4" },
     { name = "fakeredis", specifier = "~=2.26.1" },
     { name = "freezegun", specifier = "~=1.5.1" },
+    { name = "grpcio-reflection", marker = "python_full_version < '3.11'", specifier = "==1.78.0" },
     { name = "mock", specifier = ">=5.1.0" },
     { name = "moto", specifier = ">=4.2.6" },
     { name = "pre-commit", specifier = "==3.3.3" },


### PR DESCRIPTION
## Problem

`Tests / LS SQLite Ubuntu (3.10)` (and Windows 3.10) fail on develop with 167 failed tests ([example run](https://github.com/HumanSignal/label-studio/actions/runs/31190736911/job/92912638414)). 165 of them are tavern tests all erroring at setup with:

```
tavern._core.exceptions.PluginLoadError: Error loading plugin EntryPoint(name='grpc', value='tavern._plugins.grpc.tavernhook', group='tavern_grpc') - No module named 'grpc_reflection'
```

(The remaining 2 are the known order-dependent `TestColdStartScenarios` flakes, unrelated.)

## Root cause

Python 3.10 uses tavern 2.17.0, which unconditionally loads its grpc plugin whenever `grpcio` is importable (it is, transitively via `google-api-core[grpc]`), and the plugin requires `grpc_reflection`. #9882 added `grpcio-reflection==1.78.0 ; python_full_version < '3.11'` to the test group for exactly this reason.

Commit 3e9c6b3325 (BROS-1527, a frontend video fix synced from the monorepo with GitOrigin-RevId) regenerated `pyproject.toml`/`uv.lock` from a base that predates that fix and silently reverted the dependency. Python ≥3.11 jobs are unaffected because tavern 3.3.3 doesn't have this behavior.

## Fix

Re-add the dependency (with a comment explaining why it exists, to make the next accidental revert more visible) and regenerate the lock. The lock diff is minimal — only the `grpcio-reflection` entries, identical hashes to the original fix.

## Verification

On Python 3.10 with `uv sync --frozen --group test`:
- `tavern_grpc` entry point loads cleanly
- `pytest label_studio/tests/data_manager/filters/int.tavern.yml` → 4 passed (these fail on develop)

## ⚠️ Monorepo caveat

This is the second time a monorepo-synced commit clobbered these files. The same dependency line needs to be added on the monorepo side, otherwise the next sync that touches `pyproject.toml`/`uv.lock` will revert it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)