### PR TITLE
ci: Skip Netlify deploy previews when corresponding sources are unchanged

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,3 +1,9 @@
+# Skip the build (and the PR deploy preview) when nothing under docs/ changed.
+# Exit 0 = skip, non-zero = build. ':/docs' is anchored to the repo root, so it
+# works no matter which base directory the command runs from.
+[build]
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ':/docs'"
+
 [[edge_functions]]
 path = "/*"
 function = "content-negotiation"

--- a/web/libs/storybook/.storybook/main.ts
+++ b/web/libs/storybook/.storybook/main.ts
@@ -60,6 +60,13 @@ const config: StorybookConfig = {
       jsx: "automatic",
       jsxImportSource: "react",
     } as ESBuildOptions;
+    // lightningcss (rolldown-vite's default minifier) crashes on the
+    // anchor-positioning CSS in libs/ui (@position-try); use esbuild like
+    // vite.config.playground.ts does.
+    viteConfig.build = {
+      ...(viteConfig.build ?? {}),
+      cssMinify: "esbuild",
+    };
     viteConfig.resolve = viteConfig.resolve ?? {};
     viteConfig.resolve.alias = {
       ...viteConfig.resolve.alias,

--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -1,0 +1,8 @@
+# Read by the Netlify sites whose base directory is `web`:
+# label-studio-storybook and label-studio-playground.
+#
+# Skip the build (and the PR deploy preview) when nothing under web/ changed.
+# Exit 0 = skip, non-zero = build. ':/web' is anchored to the repo root, so it
+# works no matter which directory the command runs from.
+[build]
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ':/web'"

--- a/web/vite-lib-jsx-plugins.ts
+++ b/web/vite-lib-jsx-plugins.ts
@@ -5,7 +5,10 @@ import type { Plugin } from "vite";
 function pathLooksLikeLsoLibJs(id: string): boolean {
   const n = id.replace(/\\/g, "/");
   if (!/\.js$/.test(n)) return false;
-  return /\/lso\/web\/libs\//.test(n) || /\/label-studio\/web\/libs\//.test(n);
+  if (n.includes("/node_modules/")) return false;
+  // Must match any checkout location (`/opt/build/repo` on Netlify, arbitrary CI
+  // paths), not just working copies named `lso` or `label-studio`.
+  return /\/web\/libs\//.test(n);
 }
 
 function looksLikeJsxInJsSource(code: string): boolean {
@@ -62,7 +65,7 @@ export function optimizeDepsAutomaticJsxPlugin(): Plugin {
       if (!id.endsWith(".js")) return null;
       const p = id.replace(/\\/g, "/");
       const inNodeModules = p.includes("/node_modules/");
-      const inLsoLibs = p.includes("/lso/web/libs/") || p.includes("/label-studio/web/libs/");
+      const inLsoLibs = p.includes("/web/libs/");
       if (!inNodeModules && !inLsoLibs) return null;
 
       try {


### PR DESCRIPTION
## What

Two parts — together they make Netlify deploy previews both **relevant** (only build when their sources changed) and **green** (the web builds have been failing since the bun/vite migration).

### 1. Path-filtered previews ([build ignore commands](https://docs.netlify.com/configure-builds/ignore-builds/))

- `docs/netlify.toml` → **heartex-docs** and **label-studio-docs-new-theme** (base directory `docs`) skip the build unless something under `docs/` changed.
- `web/netlify.toml` (new) → **label-studio-storybook** and **label-studio-playground** (base directory `web`) skip the build unless something under `web/` changed.

Exit code drives the decision: 0 = skip, non-zero = build. The `':/docs'` / `':/web'` pathspecs are anchored to the repo root, so they resolve correctly regardless of the directory the command runs in; if `$CACHED_COMMIT_REF` is unavailable the diff errors out and the build proceeds (fails open). Skipped previews post no deploy-preview status; no Netlify checks are required on `develop`.

### 2. Fix the web preview builds (broken since FIT-1552 bun/vite migration)

- **playground**: `vite-lib-jsx-plugins.ts` only applied the JSX-in-`.js` transform when the checkout path contained `/lso/web/libs/` or `/label-studio/web/libs/`. Netlify clones to `/opt/build/repo`, so the editor's `.js` JSX files failed to parse (`Unexpected JSX expression` in `TimelineLabels.js` / `Selection.js`). Now matches any `*/web/libs/*` path outside `node_modules`.
- **storybook**: the build crashed in lightningcss (rolldown-vite's default CSS minifier) on the `@position-try` anchor-positioning rules in `libs/ui` — SIGSEGV on Linux, hard error on macOS, i.e. `storybook:build` was broken everywhere, not just on Netlify. Set `cssMinify: "esbuild"` in the storybook `viteFinal`, same workaround `vite.config.playground.ts` already uses.

Verified locally: `storybook:build` passes; `playground:build` reproduces the exact Netlify failure when run from a checkout path without `label-studio` in it and passes there with the fix.

Note: the Netlify UI build commands for the two web sites were also switched from `yarn …` to `bun run …` (site settings, not repo config) — corepack-enabled yarn refuses to run against `"packageManager": "bun@…"`.

⚠️ `vite-lib-jsx-plugins.ts` and `libs/storybook/.storybook/main.ts` are monorepo-synced (FIT-1552 came via GitOrigin) — the fix should be mirrored in hs-platform `services/lso/web` so the next sync doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)