### PR TITLE
fix: PLT-1048: Skip atomic project summary update on non-PostgreSQL backends

### DIFF
--- a/label_studio/projects/models.py
+++ b/label_studio/projects/models.py
@@ -1658,7 +1658,11 @@ class ProjectSummary(models.Model):
         return labels
 
     def update_created_annotations_and_labels(self, annotations):
-        if flag_set('fflag_fix_plt_1048_concurrent_project_summary_update_19032026_short', user='auto'):
+        # the atomic increment SQL is PostgreSQL-only (jsonb_set, :: casts),
+        # other backends would raise OperationalError on every call
+        if connection.vendor == 'postgresql' and flag_set(
+            'fflag_fix_plt_1048_concurrent_project_summary_update_19032026_short', user='auto'
+        ):
             try:
                 self._atomic_update_created_annotations_and_labels(annotations)
                 return
@@ -1780,7 +1784,11 @@ class ProjectSummary(models.Model):
         self.save(update_fields=['created_annotations', 'created_labels'])
 
     def update_created_labels_drafts(self, drafts):
-        if flag_set('fflag_fix_plt_1048_concurrent_project_summary_update_19032026_short', user='auto'):
+        # the atomic increment SQL is PostgreSQL-only (jsonb_set, :: casts),
+        # other backends would raise OperationalError on every call
+        if connection.vendor == 'postgresql' and flag_set(
+            'fflag_fix_plt_1048_concurrent_project_summary_update_19032026_short', user='auto'
+        ):
             try:
                 self._atomic_update_created_labels_drafts(drafts)
                 return

--- a/label_studio/tests/test_project_summary_atomic.py
+++ b/label_studio/tests/test_project_summary_atomic.py
@@ -1,0 +1,66 @@
+"""Atomic project summary counter updates must only run on PostgreSQL.
+
+The increment SQL uses jsonb_set and :: casts, which SQLite cannot parse
+(OperationalError: unrecognized token: ":"), so on other backends the
+counters must go through the original read-modify-write path directly.
+"""
+
+from unittest import mock
+
+import pytest
+from projects.models import ProjectSummary
+from tests.conftest import project_choices
+from tests.utils import make_project
+
+pytestmark = pytest.mark.django_db
+
+ANNOTATION = {
+    'result': [{'from_name': 'animals', 'to_name': 'image', 'type': 'choices', 'value': {'choices': ['Cat']}}]
+}
+FLAG = 'fflag_fix_plt_1048_concurrent_project_summary_update_19032026_short'
+
+
+def _flag_enabled(flag_name, *args, **kwargs):
+    return flag_name == FLAG
+
+
+def test_atomic_update_skipped_on_non_postgres(business_client):
+    project = make_project(project_choices(), business_client.user, use_ml_backend=False)
+    summary = project.summary
+
+    with (
+        mock.patch('projects.models.flag_set', side_effect=_flag_enabled),
+        mock.patch('projects.models.connection') as connection_mock,
+        mock.patch.object(ProjectSummary, '_atomic_update_created_annotations_and_labels') as atomic_annotations,
+        mock.patch.object(ProjectSummary, '_atomic_update_created_labels_drafts') as atomic_drafts,
+    ):
+        connection_mock.vendor = 'sqlite'
+        summary.update_created_annotations_and_labels([ANNOTATION])
+        summary.update_created_labels_drafts([ANNOTATION])
+
+    atomic_annotations.assert_not_called()
+    atomic_drafts.assert_not_called()
+
+    # fallback path still updates the counters
+    summary.refresh_from_db()
+    assert summary.created_annotations == {'animals|image|choices': 1}
+    assert summary.created_labels == {'animals': {'Cat': 1}}
+    assert summary.created_labels_drafts == {'animals': {'Cat': 1}}
+
+
+def test_atomic_update_used_on_postgres(business_client):
+    project = make_project(project_choices(), business_client.user, use_ml_backend=False)
+    summary = project.summary
+
+    with (
+        mock.patch('projects.models.flag_set', side_effect=_flag_enabled),
+        mock.patch('projects.models.connection') as connection_mock,
+        mock.patch.object(ProjectSummary, '_atomic_update_created_annotations_and_labels') as atomic_annotations,
+        mock.patch.object(ProjectSummary, '_atomic_update_created_labels_drafts') as atomic_drafts,
+    ):
+        connection_mock.vendor = 'postgresql'
+        summary.update_created_annotations_and_labels([ANNOTATION])
+        summary.update_created_labels_drafts([ANNOTATION])
+
+    atomic_annotations.assert_called_once_with([ANNOTATION])
+    atomic_drafts.assert_called_once_with([ANNOTATION])


### PR DESCRIPTION
## Problem

The atomic project summary counter increments introduced in PLT-1048 (904ed2c486) are built from PostgreSQL-only SQL — `jsonb_set()` and `::` casts. On SQLite this SQL can't even be parsed, so every call to `ProjectSummary.update_created_annotations_and_labels` / `update_created_labels_drafts` (i.e. every annotation or draft submission) fails with:

```
django.db.utils.OperationalError: unrecognized token: ":"
```

and logs `Atomic annotation counter increment failed, falling back to original` with a full traceback before taking the read-modify-write fallback. The counters end up correct, but the "atomic" path is dead code on SQLite and each submission pays for a doomed query plus a noisy warning (visible in every SQLite CI job log).

## Fix

Guard the flag-gated atomic path with `connection.vendor == 'postgresql'` in both callers, so non-PostgreSQL backends go straight to the original path without attempting the query. The optimization targets row-lock contention under concurrent annotators, which is a PostgreSQL production concern — SQLite loses nothing here.

## Tests

Added `label_studio/tests/test_project_summary_atomic.py`:
- non-PostgreSQL vendor + flag on → atomic helpers are not called, counters still updated via the fallback path
- PostgreSQL vendor + flag on → atomic helpers are called

🤖 Generated with [Claude Code](https://claude.com/claude-code)