### PR TITLE
docs: add release support lifecycle callout to release notes and upgrade guide

### DIFF
--- a/docs/scripts/release-notes.js
+++ b/docs/scripts/release-notes.js
@@ -44,14 +44,13 @@ meta_title: On-premises release notes for Label Studio Enterprise
 meta_description: Review new features, enhancements, and bug fixes for on-premises Label Studio Enterprise installations. 
 ---
 
+Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade.
+
 !!! attention "Release support lifecycle"
     Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
 
 !!! note
     The release notes for Label Studio Community Edition are available from the <a href="https://github.com/HumanSignal/label-studio/releases">Label Studio GitHub repository</a>.
-
-!!! note 
-    Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade. 
 
 `;
 

--- a/docs/scripts/release-notes.js
+++ b/docs/scripts/release-notes.js
@@ -44,7 +44,10 @@ meta_title: On-premises release notes for Label Studio Enterprise
 meta_description: Review new features, enhancements, and bug fixes for on-premises Label Studio Enterprise installations. 
 ---
 
-!!! note 
+!!! attention "Release support lifecycle"
+    Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
+
+!!! note
     The release notes for Label Studio Community Edition are available from the <a href="https://github.com/HumanSignal/label-studio/releases">Label Studio GitHub repository</a>.
 
 !!! note 

--- a/docs/source/guide/release_notes.md
+++ b/docs/source/guide/release_notes.md
@@ -12,6 +12,9 @@ meta_title: On-premises release notes for Label Studio Enterprise
 meta_description: Review new features, enhancements, and bug fixes for on-premises Label Studio Enterprise installations. 
 ---
 
+!!! attention "Release support lifecycle"
+    Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
+
 !!! note 
     The release notes for Label Studio Community Edition are available from the <a href="https://github.com/HumanSignal/label-studio/releases">Label Studio GitHub repository</a>.
 

--- a/docs/source/guide/release_notes.md
+++ b/docs/source/guide/release_notes.md
@@ -12,14 +12,13 @@ meta_title: On-premises release notes for Label Studio Enterprise
 meta_description: Review new features, enhancements, and bug fixes for on-premises Label Studio Enterprise installations. 
 ---
 
+Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade. 
+
 !!! attention "Release support lifecycle"
     Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
 
 !!! note 
     The release notes for Label Studio Community Edition are available from the <a href="https://github.com/HumanSignal/label-studio/releases">Label Studio GitHub repository</a>.
-
-!!! note 
-    Before upgrading, review the steps outlined in [Upgrade Label Studio Enterprise](upgrade_enterprise) and ensure that you complete the recommended tests after each upgrade. 
 
 <div class="release-note"><button class="release-note-toggle"></button>
 <a name="2331md"></a>

--- a/docs/source/guide/upgrade_enterprise.md
+++ b/docs/source/guide/upgrade_enterprise.md
@@ -13,6 +13,9 @@ parent_enterprise: "install_enterprise"
 date: 2023-09-27 10:57:03
 ---
 
+!!! attention "Release support lifecycle"
+    Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
+
 If you are using Label Studio Enterprise Cloud, all upgrades and updates are automatically deployed. 
 
 If you are using the on-premises version of Label Studio, you will need to take additional steps. 

--- a/docs/source/guide/upgrade_enterprise.md
+++ b/docs/source/guide/upgrade_enterprise.md
@@ -13,12 +13,12 @@ parent_enterprise: "install_enterprise"
 date: 2023-09-27 10:57:03
 ---
 
-!!! attention "Release support lifecycle"
-    Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
-
 If you are using Label Studio Enterprise Cloud, all upgrades and updates are automatically deployed. 
 
 If you are using the on-premises version of Label Studio, you will need to take additional steps. 
+
+!!! attention "Release support lifecycle"
+    Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.
 
 ## Upgrade process overview
 


### PR DESCRIPTION
## Reason for change

Customers reading the [On-Premises Release Notes](https://labelstud.io/guide/release_notes) or [Upgrade Label Studio Enterprise](https://labelstud.io/guide/upgrade_enterprise) pages had no indication of how long a given on-premises release is supported for. This adds a callout at the top of both pages stating the support lifecycle policy and directing customers to HumanSignal when they need to upgrade off an unsupported release.

## What changed

- Added a callout note at the top of `docs/source/guide/release_notes.md` and `docs/source/guide/upgrade_enterprise.md`:

  > Each Label Studio Enterprise on-premises release version is supported for up to 12 months from its release date. After this period, please contact your HumanSignal representative to upgrade to a currently supported release.

- Updated `docs/scripts/release-notes.js` (the Hexo build script that regenerates `release_notes.md` from `docs/source/guide/release_notes/onprem/*.md`) so the same callout is preserved the next time the file is auto-built. The comment at the top of `release_notes.md` explicitly warns against editing that file by hand outside of the generator, so the template needed the same update to keep the two in sync.

## Testing

- Manually reviewed the rendered Markdown/callout syntax against existing `!!! attention` / `!!! note` callouts already used on these pages for consistency.
- This is a docs-only change; no application code paths are affected.

## Risks

- Low risk — Markdown/documentation content only, no code or build logic changes beyond the static template string in `release-notes.js`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SLwKESzHR7pGoKY82MHbW5)_