### PR TITLE
ci: PLT-1276: Make workflows fork-friendly

### DIFF
--- a/.github/workflows/algolia-crawler-hs-docs.yml
+++ b/.github/workflows/algolia-crawler-hs-docs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   algolia_indexer:
+    if: github.repository_owner == 'HumanSignal'
     runs-on: ubuntu-latest
     env:
       APPLICATION_ID: "M7RXTHKYPM"

--- a/.github/workflows/algolia-crawler-ls-docs.yml
+++ b/.github/workflows/algolia-crawler-ls-docs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   algolia_indexer:
+    if: github.repository_owner == 'HumanSignal'
     runs-on: ubuntu-latest
     env:
       APPLICATION_ID: "M7RXTHKYPM"

--- a/.github/workflows/cicd_pipeline.yml
+++ b/.github/workflows/cicd_pipeline.yml
@@ -160,7 +160,7 @@ jobs:
     name: "Build"
     needs:
       - changed_files
-    if: startsWith(github.ref_name, 'ls-release/')
+    if: github.repository_owner == 'HumanSignal' && startsWith(github.ref_name, 'ls-release/')
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/cicd_pipeline_develop.yml
+++ b/.github/workflows/cicd_pipeline_develop.yml
@@ -37,6 +37,7 @@ jobs:
 
   build-docker:
     name: "Build"
+    if: github.repository_owner == 'HumanSignal'
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/feature-flags-update.yml
+++ b/.github/workflows/feature-flags-update.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   commit-feature-flags:
     name: "Commit Feature Flags"
-
+    if: github.repository_owner == 'HumanSignal'
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/debug-action@v3.0.0

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   dispatch:
+    if: github.repository_owner == 'HumanSignal'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -116,4 +116,9 @@ jobs:
 
       - name: "Lint migrations"
         run: |
-          uv run --no-sync python label_studio/manage.py lintmigrations --warnings-as-errors --project-root-path '.' --git-commit-id ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            echo "Base commit $BASE_SHA is not reachable (force-push or new branch), skipping migration lint"
+            exit 0
+          fi
+          uv run --no-sync python label_studio/manage.py lintmigrations --warnings-as-errors --project-root-path '.' --git-commit-id "$BASE_SHA"

--- a/.github/workflows/tests-yarn-lsf.yml
+++ b/.github/workflows/tests-yarn-lsf.yml
@@ -204,6 +204,8 @@ jobs:
     needs: cypress
     runs-on: ubuntu-latest
     if: always() && needs.cypress.result != 'failure'
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -240,7 +242,7 @@ jobs:
           node scripts/merge-cypress-coverage.js --chunks-dir coverage-chunks --out libs/editor/.nyc_output/out.json
 
       - name: Upload coverage to Codecov
-        if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: ${{ env.CODECOV_TOKEN != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v7
         with:
           name: lsf-integration

--- a/.github/workflows/tests-yarn-unit.yml
+++ b/.github/workflows/tests-yarn-unit.yml
@@ -16,6 +16,8 @@ jobs:
     name: "yarn unit"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: hmarr/debug-action@v3.0.0
 
@@ -45,7 +47,7 @@ jobs:
           bun run test:unit:coverage
 
       - name: Upload coverage to Codecov
-        if: ${{ always() && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ always() && env.CODECOV_TOKEN != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v7
         with:
           name: lsf-unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
       PYTHONPATH: label_studio
       LOG_LEVEL: ERROR
       SENTRY_ENVIRONMENT: tests-ubuntu-postgresql
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     services:
       postgres:
@@ -130,7 +131,7 @@ jobs:
         run: uv run --no-sync pytest label_studio --disable-warnings --cov=label_studio --cov-report=xml --junitxml=functional.xml --durations=30 -n auto
 
       - name: Upload coverage to Codecov
-        if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ env.CODECOV_TOKEN != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v7
         with:
           name: codecov-python-${{ matrix.python-version }}
@@ -141,7 +142,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: "Upload functional tests results to Codecov"
-        if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ env.CODECOV_TOKEN != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         uses: codecov/test-results-action@v1
         with:
           files: ./functional.xml

--- a/.github/workflows/yarn-docs.yml
+++ b/.github/workflows/yarn-docs.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     name: "Yarn docs"
-    if: "${{ github.event.commit.message != 'docs: Update tag docs and autocomplete dictionary' }}"
+    if: "${{ github.repository_owner == 'HumanSignal' && github.event.commit.message != 'docs: Update tag docs and autocomplete dictionary' }}"
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/debug-action@v3.0.0


### PR DESCRIPTION
## Problem

A push to `develop` in a fork (e.g. [this run](https://github.com/nikitabelonogovbot/label-studio/actions/runs/32009410638)) fails on 7 jobs, all for infrastructure reasons rather than real test failures:

- **Codecov uploads** (`LS PostgreSQL Ubuntu`, `yarn unit`): the guard `github.event.pull_request.head.repo.fork == false` is a no-op on `push` events — the `pull_request` context is empty, `null == false` evaluates to `true`, so the step runs without `CODECOV_TOKEN` and dies on `fail_ci_if_error: true`.
- **pgsql-migrations / Lint migrations**: `github.event.before` is unreachable after a force-push (how forks typically sync `develop`) and all-zeros on branch creation, so `lintmigrations --git-commit-id` fails with `fatal: bad object`.
- **Docker image build/push + Notify Slack**: require DockerHub/LaunchDarkly/Slack org secrets that forks don't have.

Separately, the same push also triggers **Sync**, both **Algolia indexers**, **Yarn docs**, and the scheduled **Update Feature Flags**, which all fail in forks for missing org secrets.

## Changes

**Fixed (work correctly everywhere now):**
- Codecov upload steps gate on token presence: the token is mirrored into job-level `env` and checked with `env.CODECOV_TOKEN != ''` (the `secrets` context isn't available in step-level `if`). Uploads run exactly when a token exists — always upstream, skipped in forks (unless the fork configures its own token), still skipped for fork PRs and dependabot.
- Migration lint verifies the base SHA with `git cat-file -e` and skips gracefully when it's unreachable. This also protects upstream against all-zeros SHAs on branch-creation pushes.

**Skipped outside the org (`if: github.repository_owner == 'HumanSignal'`), following the existing pattern in `build_pypi_nightly.yml`:**
- `build-docker` in both pipelines (already in the `check_gate` `allowed-skips`, so the gate stays green)
- `sync.yml`, `algolia-crawler-hs-docs.yml`, `algolia-crawler-ls-docs.yml`, `yarn-docs.yml`, `feature-flags-update.yml` — the guard evaluates in the caller's context, so `ff-command` and the release cut-off workflow calling `feature-flags-update` upstream are unaffected.

## Result

Upstream behavior is unchanged. In forks, a push to `develop` produces a green run: tests and linters run for real, org-infra jobs show as skipped.

All edited files pass `actionlint` (remaining warnings are pre-existing, e.g. `inputs.ref` in `test_migrations.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)