### PR TITLE
ci: bump PostgreSQL service images to 17

### DIFF
--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -72,7 +72,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.8
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres


### PR DESCRIPTION
## Why

Django 5.2 landed on `develop` (9a7a7c274c) and it [dropped support for PostgreSQL 13](https://docs.djangoproject.com/en/5.2/releases/5.2/) (14+ required). The **Tests / LS PostgreSQL Ubuntu (3.13)** job now fails at database setup on every test:

```
django.db.utils.NotSupportedError: PostgreSQL 14 or later is required (found 13.23).
```

Failing run: https://github.com/HumanSignal/label-studio/actions/runs/32024384547

## What

Bump the `postgres` service containers in CI to 17, matching what the internal monorepo CI already runs LSO tests against:

- `.github/workflows/tests.yml`: `postgres:13` → `postgres:17`
- `.github/workflows/test_migrations.yml`: `postgres:13.8` → `postgres:17`

No app code changes; no other `postgres:` image pins exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)