### PR TITLE
docs: Update minimum PostgreSQL version to 14

### DIFF
--- a/docs/source/guide/install_enterprise_k8s.md
+++ b/docs/source/guide/install_enterprise_k8s.md
@@ -57,7 +57,7 @@ If you use a proxy to access the internet from your Kubernetes cluster, or it is
 - **Kubernetes** — version 1.17 or higher
 - **Helm** — version 3.6.3 or higher
 - **Redis** — version 6.0.5 or higher
-- **PostgreSQL** — version 13.0 or higher
+- **PostgreSQL** — version 14.0 or higher
 - **Persistent storage** — PVC with ReadWriteMany access mode or S3-compatible object storage
 
 Redis and PostgreSQL are mandatory components of Label Studio Enterprise and are required for it to be fully functional. This chart does not include or install Redis or PostgreSQL; you must have them preconfigured (for example, according to your company’s standards) and provide connection details in your Helm values.

--- a/docs/source/includes/deploy.md
+++ b/docs/source/includes/deploy.md
@@ -12,4 +12,4 @@ Use a minimum of **8GB RAM**, but 16GB RAM is recommended. for example, t3.large
 For more on using Label Studio at scale and labeling performance, see [Start Label Studio](https://labelstud.io/guide/start).
 
 ### Software requirements
-PostgreSQL version 13 or higher or SQLite version 3.35 or higher.
+PostgreSQL version 14 or higher or SQLite version 3.35 or higher.


### PR DESCRIPTION
## Problem

The install docs state PostgreSQL 13+ is supported, but the Django 5.2 upgrade (9a7a7c274c) dropped PostgreSQL 13 support — Django 5.2 requires PostgreSQL 14+. A user on an external PostgreSQL 13 server (the documented minimum) would break at runtime after upgrading Label Studio.

CI already tests against PostgreSQL 17 (#9900), and `docker-compose.yml` ships `pgautoupgrade/pgautoupgrade:17-alpine` (auto-migrates existing volumes), so compose users are unaffected — this only concerns externally managed databases.

## Changes

- `docs/source/includes/deploy.md` — "PostgreSQL version 13 or higher" → 14 (renders into `install.md`, `install_requirements.md`, and `install_enterprise_docker.md`)
- `docs/source/guide/install_enterprise_k8s.md` — prerequisite "PostgreSQL — version 13.0 or higher" → 14.0

Release-notes mentions of "PostgreSQL 13+" are historical records of the 2.20.0 release and were left unchanged. The next release's notes should call out the new 14+ requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)