### PR TITLE
fix: scope annotation access to the active organization

### DIFF
--- a/label_studio/tasks/api.py
+++ b/label_studio/tasks/api.py
@@ -13,7 +13,7 @@ from data_manager.functions import evaluate_predictions
 from data_manager.models import PrepareParams
 from data_manager.serializers import DataManagerTaskSerializer
 from django.db import transaction
-from django.db.models import Prefetch, Q, prefetch_related_objects
+from django.db.models import Prefetch, Q, QuerySet, prefetch_related_objects
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django_filters.rest_framework import DjangoFilterBackend
@@ -971,7 +971,10 @@ class AnnotationAPI(generics.RetrieveUpdateDestroyAPIView):
     )
 
     serializer_class = AnnotationSerializer
-    queryset = Annotation.objects.all()
+    queryset = Annotation.objects.none()
+
+    def get_queryset(self) -> QuerySet[Annotation]:
+        return Annotation.objects.for_user(self.request.user)
 
     def perform_destroy(self, annotation):
         delete_annotation_with_retry(annotation)
@@ -1408,7 +1411,10 @@ class PredictionAPI(viewsets.ModelViewSet):
 )
 class AnnotationConvertAPI(generics.RetrieveAPIView):
     permission_required = ViewClassPermission(POST=all_permissions.annotations_change)
-    queryset = Annotation.objects.all()
+    queryset = Annotation.objects.none()
+
+    def get_queryset(self) -> QuerySet[Annotation]:
+        return Annotation.objects.for_user(self.request.user)
 
     def process_intermediate_state(self, annotation, draft):
         pass

--- a/label_studio/tasks/tests/test_api.py
+++ b/label_studio/tasks/tests/test_api.py
@@ -4,7 +4,7 @@ from organizations.tests.factories import OrganizationFactory
 from projects.models import Project
 from projects.tests.factories import ProjectFactory
 from rest_framework.test import APITestCase
-from tasks.models import Task
+from tasks.models import Annotation, Task
 from tasks.tests.factories import AnnotationFactory, PredictionFactory, TaskFactory
 from users.tests.factories import UserFactory
 
@@ -128,6 +128,55 @@ class TestTaskAPI(APITestCase):
         response_data = response.json()
         assert response_data['project'] == self.project.id
         assert response_data['data'] == {'text': 'test task'}
+
+
+class TestAnnotationAPIOrganizationIsolation(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        attacker_organization = OrganizationFactory(created_by_active_organization=True)
+        cls.attacker = attacker_organization.created_by
+
+        victim_organization = OrganizationFactory(created_by_active_organization=True)
+        victim_project = ProjectFactory(organization=victim_organization)
+        victim_task = TaskFactory(project=victim_project)
+        cls.annotation = AnnotationFactory(
+            task=victim_task,
+            project=victim_project,
+            completed_by=victim_organization.created_by,
+            result=[],
+            lead_time=1.5,
+        )
+
+    def setUp(self):
+        self.client.force_authenticate(user=self.attacker)
+
+    def test_cannot_retrieve_annotation_from_another_organization(self):
+        response = self.client.get(f'/api/annotations/{self.annotation.id}/')
+
+        assert response.status_code == 404
+
+    def test_cannot_update_annotation_from_another_organization(self):
+        response = self.client.patch(
+            f'/api/annotations/{self.annotation.id}/',
+            data={'lead_time': 10},
+            format='json',
+        )
+
+        assert response.status_code == 404
+        self.annotation.refresh_from_db()
+        assert self.annotation.lead_time == 1.5
+
+    def test_cannot_delete_annotation_from_another_organization(self):
+        response = self.client.delete(f'/api/annotations/{self.annotation.id}/')
+
+        assert response.status_code == 404
+        assert Annotation.objects.filter(pk=self.annotation.id).exists()
+
+    def test_cannot_convert_annotation_from_another_organization(self):
+        response = self.client.post(f'/api/annotations/{self.annotation.id}/convert-to-draft')
+
+        assert response.status_code == 404
+        assert Annotation.objects.filter(pk=self.annotation.id).exists()
 
 
 class TestTaskAPIResolveUri(APITestCase):


### PR DESCRIPTION
## Reason for change

`AnnotationAPI` and `AnnotationConvertAPI` use unscoped annotation querysets. This allows an authenticated user to address annotations outside their active organization.

## What changed

- Scope annotation detail access through `Annotation.objects.for_user(request.user)`.
- Apply the same organization scoping to annotation-to-draft conversion.
- Add cross-organization regression tests for GET, PATCH, DELETE, and convert-to-draft.
- Verify that update and delete attempts do not modify the target annotation.

## Rollout strategy

No migration or feature flag is required. This restores the organization boundary already used by other task, project, and prediction endpoints.

## Testing

- `label_studio/tasks/tests/test_api.py`: 34 passed
- `label_studio/tests/test_annotations.py`: 19 passed
- Existing same-organization annotation retrieval and deletion tests pass
- Ruff lint and format checks pass
- Bandit with the repository custom plugin passes
- `git diff --check` passes

## Acceptance criteria

- When an authenticated user requests an annotation belonging to another organization, GET, PATCH, DELETE, and convert-to-draft return 404.
- Cross-organization PATCH does not modify the annotation.
- Cross-organization DELETE and convert-to-draft do not delete the annotation.
- Annotation access within the active organization continues to work.

## Risks

Low. The behavioral change is limited to annotation access outside the requesting user’s active organization.

## Reviewer notes

These tests use Django `APITestCase` instead of Tavern because the regression requires two organizations and direct verification that rejected update and delete requests do not mutate database state.

Fixes #9796