### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can deploy Label Studio with one click in Heroku, Microsoft Azure, or Google
 <a href="https://www.heroku.com/deploy?template=https://github.com/HumanSignal/label-studio/tree/heroku-persistent-pg"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy" height="30px"></a>
 [<img src="https://aka.ms/deploytoazurebutton" height="30px">](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fhumansignal%2Flabel-studio%2Fdevelop%2Fazuredeploy.json)
 [<img src="https://deploy.cloud.run/button.svg" height="30px">](https://deploy.cloud.run)
-[<img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="30px">](https://repocloud.io/details/Label%20Studio/)
+[<img src="https://dnk92k33or340.cloudfront.net/rcdeploy-30px.png" alt="Deploy on RepoCloud" height="30px">](https://repocloud.io/details/Label%20Studio/)
 
 
 #### Apply frontend changes

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ You can deploy Label Studio with one click in Heroku, Microsoft Azure, or Google
 <a href="https://www.heroku.com/deploy?template=https://github.com/HumanSignal/label-studio/tree/heroku-persistent-pg"><img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy" height="30px"></a>
 [<img src="https://aka.ms/deploytoazurebutton" height="30px">](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fhumansignal%2Flabel-studio%2Fdevelop%2Fazuredeploy.json)
 [<img src="https://deploy.cloud.run/button.svg" height="30px">](https://deploy.cloud.run)
+[<img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="30px">](https://repocloud.io/details/Label%20Studio/)
 
 
 #### Apply frontend changes


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option
alongside the existing providers (Heroku, Microsoft Azure, Google Cloud Platform).

RepoCloud provides managed cloud hosting for open-source applications
with one-click deployment.

- Adds deploy button to `README.md`
- Uses the same `height="30px"` format as existing deploy buttons
- Links to: https://repocloud.io/details/Label%20Studio/