### PR TITLE
fix: preserve base path in View All link

### DIFF
--- a/web/apps/labelstudio/src/pages/Home/HomePage.tsx
+++ b/web/apps/labelstudio/src/pages/Home/HomePage.tsx
@@ -16,6 +16,7 @@ import { useAPI } from "../../providers/ApiProvider";
 import { CreateProject } from "../CreateProject/CreateProject";
 import { InviteLink } from "../Organization/PeoplePage/InviteLink";
 import type { Page } from "../types/Page";
+import { ViewAllProjectsLink } from "./ViewAllProjectsLink";
 import {
   creationDialogOpen,
   invitationOpen,
@@ -169,10 +170,7 @@ export const HomePage: Page = () => {
             title={
               data && data?.count > 0 ? (
                 <>
-                  Recent Projects{" "}
-                  <a href="/projects" className="text-lg font-normal hover:underline">
-                    View All
-                  </a>
+                  Recent Projects <ViewAllProjectsLink />
                 </>
               ) : null
             }

--- a/web/apps/labelstudio/src/pages/Home/ViewAllProjectsLink.test.tsx
+++ b/web/apps/labelstudio/src/pages/Home/ViewAllProjectsLink.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { ViewAllProjectsLink } from "./ViewAllProjectsLink";
+
+describe("ViewAllProjectsLink", () => {
+  const originalAppSettings = window.APP_SETTINGS;
+
+  afterEach(() => {
+    window.APP_SETTINGS = originalAppSettings;
+    (globalThis as any).APP_SETTINGS = originalAppSettings;
+  });
+
+  it("links to projects when Label Studio is hosted at the root", () => {
+    window.APP_SETTINGS = { ...originalAppSettings, hostname: "http://localhost" };
+    (globalThis as any).APP_SETTINGS = window.APP_SETTINGS;
+
+    render(<ViewAllProjectsLink />);
+
+    expect(screen.getByRole("link", { name: "View All" })).toHaveAttribute("href", "http://localhost/projects");
+  });
+
+  it("includes the base path when Label Studio is hosted below the root", () => {
+    window.APP_SETTINGS = { ...originalAppSettings, hostname: "http://localhost/label-studio" };
+    (globalThis as any).APP_SETTINGS = window.APP_SETTINGS;
+
+    render(<ViewAllProjectsLink />);
+
+    expect(screen.getByRole("link", { name: "View All" })).toHaveAttribute(
+      "href",
+      "http://localhost/label-studio/projects",
+    );
+  });
+});

--- a/web/apps/labelstudio/src/pages/Home/ViewAllProjectsLink.tsx
+++ b/web/apps/labelstudio/src/pages/Home/ViewAllProjectsLink.tsx
@@ -1,0 +1,7 @@
+import { absoluteURL } from "../../utils/helpers";
+
+export const ViewAllProjectsLink = () => (
+  <a href={absoluteURL("/projects")} className="text-lg font-normal hover:underline">
+    View All
+  </a>
+);


### PR DESCRIPTION
## Reason for change
The Home page `View All` link used a root-relative `/projects` URL. When Label Studio is hosted below a path prefix, the link drops that prefix and navigates to the wrong location.

## Solution
- build the projects URL with the existing `absoluteURL` helper
- isolate the link in a small component for focused regression coverage
- test both root and non-root deployments

## Testing
- `bun test --dom apps/labelstudio/src/pages/Home/ViewAllProjectsLink.test.tsx`
- 2 passed, 0 failed
- Biome lint/format passed
- `git diff --check` passed

## Acceptance criteria
- When Label Studio is hosted at the root, `View All` links to `/projects`.
- When Label Studio is hosted below `/label-studio`, `View All` links to `/label-studio/projects`.

## Risk
Low. The change only replaces the hard-coded link target with the existing URL helper.

Fixes #9913.