### PR TITLE
fix: preserve base path for Heidi tips

### DIFF
--- a/web/apps/labelstudio/src/components/HeidiTips/utils.test.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/utils.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { loadLiveTipsCollection } from "./utils";
+
+describe("loadLiveTipsCollection", () => {
+  const originalHostname = APP_SETTINGS.hostname;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    APP_SETTINGS.hostname = originalHostname;
+  });
+
+  it.each([
+    ["a root deployment", "http://localhost/", "http://localhost/heidi-tips/"],
+    ["a non-root deployment", "http://localhost/label-studio/", "http://localhost/label-studio/heidi-tips/"],
+  ])("fetches Heidi tips with the configured base path for %s", (_scenario, hostname, expectedURL) => {
+    APP_SETTINGS.hostname = hostname;
+    const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    loadLiveTipsCollection();
+
+    expect(fetchMock.mock.calls[0][0]).toBe(expectedURL);
+  });
+});

--- a/web/apps/labelstudio/src/components/HeidiTips/utils.ts
+++ b/web/apps/labelstudio/src/components/HeidiTips/utils.ts
@@ -1,5 +1,6 @@
 import { defaultTipsCollection } from "./content";
 import type { Tip, TipsCollection } from "./types";
+import { absoluteURL } from "../../utils/helpers";
 
 const STORE_KEY = "heidi_ignored_tips";
 const EVENT_NAMESPACE_KEY = "heidi_tips";
@@ -58,7 +59,7 @@ export const loadLiveTipsCollection = () => {
   const abortTimeout = setTimeout(abortController.abort, MAX_TIMEOUT);
 
   // Fetch from github raw liveContent.json proxied through the server
-  fetch("/heidi-tips", {
+  fetch(absoluteURL("/heidi-tips/"), {
     headers: {
       "Cache-Control": "no-cache",
       "Content-Type": "application/json",


### PR DESCRIPTION
## Reason for change
The Heidi Tips request uses a root-relative `/heidi-tips` URL. When Label Studio is hosted below a path prefix, the browser sends the request to the domain root instead of the configured application path.

## Solution
- build the Heidi Tips endpoint with the existing `absoluteURL` helper
- retain the trailing slash used by the Django route
- cover root and non-root deployments with focused tests

## Testing
- `bun test --dom apps/labelstudio/src/components/HeidiTips/utils.test.ts`
- 2 passed, 0 failed
- Biome passed with only the existing `document.cookie` warning
- `git diff --check` passed

## Acceptance criteria
- When hosted at the root, Heidi Tips requests `/heidi-tips/`.
- When hosted below `/basepath`, Heidi Tips requests `/basepath/heidi-tips/`.

## Risk
Low. The change uses the existing application URL helper and only affects the endpoint URL construction.

Fixes the Heidi Tips sub-path case in #9652.