### PR TITLE
docs: add service accounts blurb to 2.35.0 changelog

### DIFF
--- a/docs/source/guide/release_notes/onprem/2.35.0.md
+++ b/docs/source/guide/release_notes/onprem/2.35.0.md
@@ -48,6 +48,12 @@ The project **Members** page now lives under **Dashboard**, so per-project membe
 
 For more information, see the [Members dashboard](dashboard_members).
 
+#### Organization: manage API-only service accounts
+
+Give scripts and integrations their own credentials instead of routing them through a person's login. Service accounts get programmatic access to the Label Studio API — scoped to an organization role and, where applicable, specific workspaces and projects — but can't sign in or interact with the platform through the UI.
+
+For more information, see [Service accounts](service-accounts).
+
 #### Platform and reliability
 
 We continued hardening the platform behind the scenes: dependency security updates, bug fixes, and reliability improvements.

--- a/docs/source/guide/release_notes/onprem/2.35.0.md
+++ b/docs/source/guide/release_notes/onprem/2.35.0.md
@@ -23,6 +23,12 @@ For more information, see [Interfaces](interfaces).
 !!! attention Availability
     Custom Interfaces ships behind a feature flag in 2.35. Contact your HumanSignal account team to turn it on for your workspace.
 
+#### Organization: manage API-only service accounts
+
+Give scripts and integrations their own credentials instead of routing them through a user's login. Service accounts get programmatic access to the Label Studio API, and can be scoped to an organization, workspace, or project level. Service accounts cannot sign in or interact with the platform through the UI.
+
+For more information, see [Service accounts](service-accounts).
+
 ### Feature updates
 
 #### Video labeling: autotrack VideoVector regions with SAM2
@@ -47,12 +53,6 @@ For more information, see [Review settings](project_settings_lse#Review) and [Us
 The project **Members** page now lives under **Dashboard**, so per-project member management sits with the rest of a project's analytics instead of in a separate location.
 
 For more information, see the [Members dashboard](dashboard_members).
-
-#### Organization: manage API-only service accounts
-
-Give scripts and integrations their own credentials instead of routing them through a person's login. Service accounts get programmatic access to the Label Studio API — scoped to an organization role and, where applicable, specific workspaces and projects — but can't sign in or interact with the platform through the UI.
-
-For more information, see [Service accounts](service-accounts).
 
 #### Platform and reliability
 

--- a/docs/source/guide/release_notes/onprem/2.35.0.md
+++ b/docs/source/guide/release_notes/onprem/2.35.0.md
@@ -4,7 +4,7 @@ hide_sidebar: true
 
 ## Label Studio Enterprise 2.35.0
 
-<div class="onprem-highlight">Custom Interfaces, VideoVector autotracking with SAM2, agreement-based review sampling, and bulk review from the Data Manager. SAML SSO now requires a signed assertion (breaking change). </div>
+<div class="onprem-highlight">Custom Interfaces, service accounts, VideoVector autotracking with SAM2, agreement-based review sampling, and bulk review from the Data Manager. SAML SSO now requires a signed assertion (breaking change). </div>
 
 *Jul 29, 2026*
 


### PR DESCRIPTION
## What does this PR do?

Adds a short blurb about [service accounts](https://docs.humansignal.com/guide/service-accounts.html) to the [2.35.0 on-prem changelog](https://docs.humansignal.com/guide/release_notes/onprem/2.35.0.html), under **Feature updates**, matching the existing voice/format of the other entries on that page (short problem framing + description, followed by a "For more information, see [...]" link).

## Why is this change necessary?

Service accounts weren't previously called out in the 2.35.0 changelog. This adds a discoverable pointer to the existing docs page for admins scanning release notes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yj7gaebGX9khvkzdy8M5R

---
_Generated by [Claude Code](https://claude.ai/code/session_014yj7gaebGX9khvkzdy8M5R)_