### PR TITLE
fix: use timezone-aware dates for token queries

### DIFF
--- a/label_studio/jwt_auth/views.py
+++ b/label_studio/jwt_auth/views.py
@@ -1,7 +1,7 @@
 import logging
-from datetime import datetime
 
 from core.permissions import ViewClassPermission, all_permissions
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from jwt_auth.auth import TokenAuthenticationPhaseout
@@ -149,10 +149,10 @@ class LSAPITokenView(generics.ListCreateAPIView):
         # Would be ideal to just add a "blacklisted" attr to our own subclass of
         # OutstandingToken so we can check at that level, or just clean up
         # OutstandingTokens that have been blacklisted every so often.
-        current_blacklisted_tokens = BlacklistedToken.objects.filter(token__expires_at__gt=datetime.now()).values_list(
+        current_blacklisted_tokens = BlacklistedToken.objects.filter(token__expires_at__gt=timezone.now()).values_list(
             'token_id', flat=True
         )
-        return OutstandingToken.objects.filter(user_id=self.request.user.id, expires_at__gt=datetime.now()).exclude(
+        return OutstandingToken.objects.filter(user_id=self.request.user.id, expires_at__gt=timezone.now()).exclude(
             id__in=current_blacklisted_tokens
         )
 

--- a/label_studio/tests/jwt_auth/test_views.py
+++ b/label_studio/tests/jwt_auth/test_views.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from jwt_auth.models import LSAPIToken
 from rest_framework import status
@@ -5,6 +7,21 @@ from rest_framework.test import APIClient
 from rest_framework_simplejwt.exceptions import TokenError
 from tests.jwt_auth.utils import create_user_with_token_settings
 from tests.utils import mock_feature_flag
+
+
+@mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)
+@pytest.mark.django_db
+def test_list_tokens_does_not_use_naive_datetimes():
+    user = create_user_with_token_settings(api_tokens_enabled=True, legacy_api_tokens_enabled=False)
+    client = APIClient()
+    client.force_authenticate(user)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        response = client.get('/api/token/')
+
+    assert response.status_code == status.HTTP_200_OK
+    assert not [warning for warning in caught if 'received a naive datetime' in str(warning.message)]
 
 
 @mock_feature_flag(flag_name='fflag__feature_develop__prompts__dia_1829_jwt_token_auth', value=True)


### PR DESCRIPTION
## Description

Fixes #9716.

Token listing filtered Django `DateTimeField`s with naive `datetime.now()` values while timezone support is enabled. An authenticated `GET /api/token/` consequently emitted two `RuntimeWarning`s.

Use Django's timezone-aware clock for both expiry filters. The behavior and response shape are otherwise unchanged.

## Tests

- `DJANGO_DB=sqlite uv run --frozen --group test pytest label_studio/tests/jwt_auth/test_views.py -q` — 8 passed
- `DJANGO_DB=sqlite uv run --frozen --group test pytest label_studio/tests/jwt_auth -q` — 26 passed
- `uv run --frozen --group test pre-commit run --hook-stage pre-push --files label_studio/jwt_auth/views.py label_studio/tests/jwt_auth/test_views.py` — Ruff lint and format passed

Acceptance criterion: when an authenticated user lists API tokens with timezone support enabled, the endpoint returns 200 without a naive-datetime warning.

Risk is low: only the source of the current timestamp changes, from server-local naive time to Django's configured timezone-aware time.
