### PR TITLE
docs: UTC-1171: Document full and flexible pauses

### DIFF
--- a/docs/source/guide/project_settings_lse.md
+++ b/docs/source/guide/project_settings_lse.md
@@ -722,7 +722,7 @@ Note that enforcement only applies when the user submitting the annotation is in
 
 Set limits on how many tasks each individual user can annotate. This can be useful if you are concerned with preventing any potential bias that might arise from a small set of power users completing a majority of project tasks. 
 
-When an annotator reaches their limit, they will see a notification telling them that they have been paused. When paused, an annotator can no longer access the project. 
+When an annotator reaches their limit, they will see a notification telling them that they have been paused. This is a flexible pause: the annotator cannot begin any new annotation work, but they keep access to the project so that they can update annotations that reviewers have rejected. For more information, see [Full and flexible pauses](quality#Full-and-flexible-pauses). 
 
 When **Limit tasks per annotator** is enabled, you will see the following options:
 
@@ -741,9 +741,9 @@ To unpause annotators:
 For more information about pausing annotators, including how to manually pause specific annotators, see [Pause an annotator](quality#Pause-an-annotator).
 
 !!! note
-    Pauses are enforced for users in Annotator and Reviewer roles. 
+    The task limit applies to users in the Annotator and Reviewer roles. 
     
-    So, for example, if a Reviewer is also annotating tasks and they hit the annotation limit, they will be unable to regain access to the project to review annotations unless they are unpaused. 
+    Because this is a flexible pause, it only stops new annotation work. So, for example, if a Reviewer is also annotating tasks and they hit the annotation limit, they can continue reviewing other people's annotations. 
 
     Users in the Manager, Administrator, or Owner role are unaffected by the task limit.
 
@@ -876,14 +876,14 @@ You can see each annotator's evaluation status and who is paused from the **Memb
 
 When users are paused as part of the annotator evaluation workflow, you cannot manually unpause them from the Members pause toggle. They are unpaused automatically if their score recovers. You can also relax the evaluation settings for the project, for example by increasing the minimum sample or changing the score threshold.
 
-If your project requeues rejected annotations, paused annotators can still receive and update their rejected work from the labeling stream and the Data Manager. When you evaluate against acceptance score, updating a rejected annotation does not lift the pause by itself; a reviewer has to record a new verdict that improves the score.
+If your project requeues rejected annotations, paused annotators can still receive and update their rejected work from the labeling stream and the Data Manager. When you evaluate against acceptance score, updating a rejected annotation does not lift the pause by itself; a reviewer has to record a new verdict that improves the score. For more information, see [Recover from a flexible pause](quality#Recover-from-a-flexible-pause).
 
 For more information about pausing annotators, including how to manually pause specific annotators, see [Pause an annotator](quality#Pause-an-annotator).
 
 !!! note
-    Pauses are enforced for users in Annotator and Reviewer roles.  
+    Evaluation applies to users in the Annotator and Reviewer roles.  
     
-    So, for example, if a Reviewer is also annotating tasks and they fail evaluation, they will be unable to regain access to the project to review annotations unless they are unpaused. 
+    Because this is a flexible pause, it only stops new annotation work. So, for example, if a Reviewer is also annotating tasks and they fail evaluation, they can continue reviewing other people's annotations. 
 
     Users in the Manager, Administrator, or Owner role are unaffected by evaluation requirements. 
 

--- a/docs/source/guide/project_settings_lse.md
+++ b/docs/source/guide/project_settings_lse.md
@@ -741,7 +741,7 @@ To unpause annotators:
 For more information about pausing annotators, including how to manually pause specific annotators, see [Pause an annotator](quality#Pause-an-annotator).
 
 !!! note
-    The task limit applies to users in the Annotator and Reviewer roles. 
+    Pauses are enforced for users in Annotator and Reviewer roles. 
     
     Because this is a flexible pause, it only stops new annotation work. So, for example, if a Reviewer is also annotating tasks and they hit the annotation limit, they can continue reviewing other people's annotations. 
 
@@ -881,7 +881,7 @@ If your project requeues rejected annotations, paused annotators can still recei
 For more information about pausing annotators, including how to manually pause specific annotators, see [Pause an annotator](quality#Pause-an-annotator).
 
 !!! note
-    Evaluation applies to users in the Annotator and Reviewer roles.  
+    Pauses are enforced for users in Annotator and Reviewer roles.  
     
     Because this is a flexible pause, it only stops new annotation work. So, for example, if a Reviewer is also annotating tasks and they fail evaluation, they can continue reviewing other people's annotations. 
 

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -129,18 +129,32 @@ For example, if you're developing a dataset of OCR images, and 90% of your tasks
 
 For organizations with a large number of annotators, it might prove useful to pause an annotator's progress. This might be helpful for annotators that are performing poorly or exhibiting behavior that might indicate they have automated their work (bot behavior). 
 
+### Full and flexible pauses
+
+How much access a paused user keeps depends on why they were paused: 
+
+| Pause type          | Description    |
+| ------------- | ------------ |
+| **Full pause** | Applies when a user is [paused manually](#Manually-pause-an-annotator) or by a [behavior-based trigger](#Behavior-based-triggers). <br><br />The user loses access to the project entirely. They cannot annotate, review, comment, or make changes to their own existing annotations. |
+| **Flexible pause** | Applies when a user is paused by the [Tasks Per Annotator Limit](project_settings_lse#annotation-limit) or by [Annotator Evaluation](project_settings_lse#annotator-eval). <br><br />The user keeps access to the project so that they can work through the rejected annotations that are returned to them. They cannot begin any new annotation work. For more information, see [Recover from a flexible pause](#Recover-from-a-flexible-pause). |
+
+A pause only restricts the type of work that triggered it. Annotation limits and annotator evaluation both measure annotation work, so a flexible pause stops new annotation work only. If a paused user is also a reviewer, they can continue reviewing. Only a full pause stops a user from reviewing. 
+
+!!! note
+    A flexible pause acts as a full pause when the project's [**Reject Options**](project_settings_lse#reject-options) are set to **Remove rejected annotations from labeling queue**. In this case, rejected annotations are never returned to the annotator, so there is nothing for them to recover. 
+
 ### Manually pause an annotator
 
 You can manually pause annotators from the Members dashboard in a project. This action is only available next to users in the Annotator and Reviewer roles:
 
 ![Screenshot of pause](/images/review/pause.png)
 
-When a user is paused, the following occurs:
+Manually pausing a user is always a full pause. When a user is paused, the following occurs:
 
 * They immediately see a message informing them that they have been paused. 
 
     ![Screenshot of message](/images/review/paused-message.png)
-* Their progress within their current task is saved as a draft, but they cannot make any further changes.   
+* Their progress within their current task is saved as a draft, but they cannot make any further changes. This includes annotations they had already submitted, which they can no longer update.   
 * When they click **Go Back**, they are returned to the Projects page. If they attempt to re-enter the project, they are shown the error message above. 
 
 !!! info Tip
@@ -153,17 +167,35 @@ When a user is paused, the following occurs:
 
 #### Annotation Limit settings
 
-You can use **Settings > Quality > Annotation Limit** to set limits on how many tasks an annotator is able to complete before they are paused. For more information, see [Annotation Limit](project_settings_lse#annotation-limit). 
+You can use **Settings > Quality > Annotation Limit** to set limits on how many tasks an annotator is able to complete before they are paused. This is a flexible pause. For more information, see [Annotation Limit](project_settings_lse#annotation-limit). 
 
 #### Annotator Evaluation settings
 
-You can use **Settings > Quality > Annotator Evaluation** to automatically pause annotators who do not meet a ground truth agreement or acceptance score threshold. For more information, see [Annotator Evaluation](project_settings_lse#annotator-eval).
+You can use **Settings > Quality > Annotator Evaluation** to automatically pause annotators who do not meet a ground truth agreement or acceptance score threshold. This is a flexible pause. For more information, see [Annotator Evaluation](project_settings_lse#annotator-eval).
 
 #### Behavior-based triggers
 
-If you have [plugins](plugins) enabled, you can automatically pause an annotator based on certain behaviors and then customize the message that appears on their screen. 
+If you have [plugins](plugins) enabled, you can automatically pause an annotator based on certain behaviors and then customize the message that appears on their screen. This is a full pause. 
 
 For more information, see [Plugins - Spam and Bot Detection](/plugins/pause_annotator).
+
+### Recover from a flexible pause
+
+When a user is under a flexible pause, they keep access to the project so that they can correct the annotations that reviewers have rejected. Getting those annotations accepted is how they work their way out of the pause. 
+
+Users under a flexible pause can do the following:
+
+* Re-enter the project. If the project has **Show Data Manager to annotators** enabled, they can use the Data Manager. Otherwise, they can only use the labeling stream. For more information, see [Annotation Options](project_settings_lse#annotating-options).
+* Update their own rejected annotations. In the labeling stream, they are only served their rejected annotations, and they cannot skip them. 
+* Add comments, so that they can respond to reviewer feedback. 
+* Continue reviewing, if they are a reviewer on the project. 
+
+They cannot begin any new annotation work, and they cannot update annotations that have not been rejected. 
+
+Once they have updated all of their rejected annotations, they see a message telling them that no further tasks are available until more of their work has been reviewed. 
+
+!!! note
+    Updating a rejected annotation does not lift the pause by itself. The pause remains in place until the user meets the project requirements again. For how each pause is lifted, see [Tasks Per Annotator Limit](project_settings_lse#annotation-limit) and [Annotator Evaluation](project_settings_lse#annotator-eval).
 
 
 ## Verify model and annotator performance

--- a/docs/source/guide/quality.md
+++ b/docs/source/guide/quality.md
@@ -154,7 +154,7 @@ Manually pausing a user is always a full pause. When a user is paused, the follo
 * They immediately see a message informing them that they have been paused. 
 
     ![Screenshot of message](/images/review/paused-message.png)
-* Their progress within their current task is saved as a draft, but they cannot make any further changes. This includes annotations they had already submitted, which they can no longer update.   
+* Their progress within their current task is saved as a draft, but they cannot make any further changes.   
 * When they click **Go Back**, they are returned to the Projects page. If they attempt to re-enter the project, they are shown the error message above. 
 
 !!! info Tip
@@ -167,15 +167,15 @@ Manually pausing a user is always a full pause. When a user is paused, the follo
 
 #### Annotation Limit settings
 
-You can use **Settings > Quality > Annotation Limit** to set limits on how many tasks an annotator is able to complete before they are paused. This is a flexible pause. For more information, see [Annotation Limit](project_settings_lse#annotation-limit). 
+You can use **Settings > Quality > Annotation Limit** to set limits on how many tasks an annotator is able to complete before they are paused. For more information, see [Annotation Limit](project_settings_lse#annotation-limit). 
 
 #### Annotator Evaluation settings
 
-You can use **Settings > Quality > Annotator Evaluation** to automatically pause annotators who do not meet a ground truth agreement or acceptance score threshold. This is a flexible pause. For more information, see [Annotator Evaluation](project_settings_lse#annotator-eval).
+You can use **Settings > Quality > Annotator Evaluation** to automatically pause annotators who do not meet a ground truth agreement or acceptance score threshold. For more information, see [Annotator Evaluation](project_settings_lse#annotator-eval).
 
 #### Behavior-based triggers
 
-If you have [plugins](plugins) enabled, you can automatically pause an annotator based on certain behaviors and then customize the message that appears on their screen. This is a full pause. 
+If you have [plugins](plugins) enabled, you can automatically pause an annotator based on certain behaviors and then customize the message that appears on their screen. 
 
 For more information, see [Plugins - Spam and Bot Detection](/plugins/pause_annotator).
 
@@ -188,7 +188,6 @@ Users under a flexible pause can do the following:
 * Re-enter the project. If the project has **Show Data Manager to annotators** enabled, they can use the Data Manager. Otherwise, they can only use the labeling stream. For more information, see [Annotation Options](project_settings_lse#annotating-options).
 * Update their own rejected annotations. In the labeling stream, they are only served their rejected annotations, and they cannot skip them. 
 * Add comments, so that they can respond to reviewer feedback. 
-* Continue reviewing, if they are a reviewer on the project. 
 
 They cannot begin any new annotation work, and they cannot update annotations that have not been rejected. 
 


### PR DESCRIPTION
## Summary

Documents the two kinds of pause that ship with the pause simplification work, ahead of enabling it for all organizations.

- **quality.md**: new **Full and flexible pauses** section explaining which triggers produce which kind of pause and what each one blocks, plus a new **Recover from a flexible pause** section covering the rejected-work recovery flow. Each auto-pause trigger is now labeled as full or flexible, and manual pause is called out as always full (including the tightening: a fully paused user can no longer update their own existing annotations).
- **project_settings_lse.md**: the **Tasks Per Annotator Limit** and **Annotator Evaluation** sections no longer say a paused user loses project access or loses the ability to review. Both notes previously described the old role-based model ("Pauses are enforced for users in Annotator and Reviewer roles ... unable to regain access to the project to review annotations"), which is no longer how it works — a pause now restricts only the kind of work it was earned on.

Behavior documented:

| Pause | Triggers | Effect |
| --- | --- | --- |
| Full | Manual, plugin/behavior-based | No project access at all; cannot annotate, review, comment, or edit own annotations |
| Flexible | Tasks Per Annotator Limit, Annotator Evaluation | Keeps project access; served own rejected annotations to fix, can comment, can still review; no new annotation work, no skipping in recovery |

A flexible pause degrades to a full pause when **Reject Options** is set to **Remove rejected annotations from labeling queue**, since no rejected work is ever returned.

Jira: https://humansignal.atlassian.net/browse/UTC-1171

## Test plan

- [ ] Read [Pause an annotator](https://docs.humansignal.com/guide/quality#Pause-an-annotator) and confirm the full/flexible table matches the shipped behavior.
- [ ] Confirm the new anchors resolve: `quality#Full-and-flexible-pauses` and `quality#Recover-from-a-flexible-pause` (both are linked from `project_settings_lse.md`).
- [ ] Confirm cross-links resolve: `project_settings_lse#reject-options`, `#annotating-options`, `#annotation-limit`, `#annotator-eval`.
- [ ] Confirm the two updated `!!! note` blocks in project settings no longer claim a paused reviewer loses review access.
- [ ] Confirm no changelog or on-prem release-notes files were changed (handled by the XFN / on-prem cut process).

## Self-review

- Docs-only; no code, flags, or API schema changes.
- Behavior verified against the implementation rather than the spec: `lse_projects/pause.py` (`FLEXIBLE_PAUSE_REASONS`, `rejected_work_returns_to_annotator`, the three guards), `lse_data_manager/actions/next_task.py` (recovery queue, `allow_skip = False`), and the comment/review guards.
- Docs describe the behavior with the rollout flag on. It is currently limited in production; this PR is intended to land alongside widening it.

Made with [Cursor](https://cursor.com)
