### PR TITLE
fix: scope storage-URI resolve endpoints to the user's organization

### DIFF
--- a/label_studio/io_storages/proxy_api.py
+++ b/label_studio/io_storages/proxy_api.py
@@ -392,7 +392,7 @@ class TaskResolveStorageUri(ResolveStorageUriAPIMixin, APIView):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            task = Task.objects.get(pk=task_id)
+            task = Task.objects.get(pk=task_id, project__organization=request.user.active_organization)
         except Task.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -420,7 +420,7 @@ class ProjectResolveStorageUri(ResolveStorageUriAPIMixin, APIView):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            project = Project.objects.get(pk=project_id)
+            project = Project.objects.get(pk=project_id, organization=request.user.active_organization)
         except Project.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/label_studio/io_storages/tests/test_proxy_api.py
+++ b/label_studio/io_storages/tests/test_proxy_api.py
@@ -11,11 +11,14 @@ from io_storages.proxy_api import (
     ResolveStorageUriAPIMixin,
     TaskResolveStorageUri,
 )
+from organizations.tests.factories import OrganizationFactory
 from projects.models import Project
+from projects.tests.factories import ProjectFactory
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 from tasks.models import Task
+from tasks.tests.factories import TaskFactory
 
 
 class TestResolveStorageUriAPIMixin(unittest.TestCase):
@@ -633,7 +636,7 @@ class TestTaskResolveStorageUri:
         force_authenticate(request, user=self.user)
         response = self.view(request, task_id=1)
 
-        mock_task_get.assert_called_once_with(pk=1)
+        mock_task_get.assert_called_once_with(pk=1, project__organization=self.user.active_organization)
         # Use any_call instead of assert_called_once_with to handle DRF request vs WSGIRequest
         assert mock_resolve.call_args is not None
         assert mock_resolve.call_args[0][1] == 'test'
@@ -690,9 +693,63 @@ class TestProjectResolveStorageUri:
         force_authenticate(request, user=self.user)
         response = self.view(request, project_id=1)
 
-        mock_project_get.assert_called_once_with(pk=1)
+        mock_project_get.assert_called_once_with(pk=1, organization=self.user.active_organization)
         # Use any_call instead of assert_called_once_with to handle DRF request vs WSGIRequest
         assert mock_resolve.call_args is not None
         assert mock_resolve.call_args[0][1] == 'test'
         assert mock_resolve.call_args[0][2] == self.project
         assert response.status_code == status.HTTP_200_OK
+
+
+class TestResolveStorageUriCrossOrganization:
+    """The resolve endpoints look a task or project up by primary key, so they must be
+    scoped to the requesting user's organization. Without that scope any authenticated
+    user reaches another tenant's storage through a guessable id (#9924)."""
+
+    FILEURI = base64.urlsafe_b64encode(b's3://victim-bucket/secret.jpg').decode()
+    RESOLVE = 'io_storages.proxy_api.ResolveStorageUriAPIMixin.resolve'
+
+    def _get(self, user, url):
+        client = APIClient()
+        client.force_authenticate(user=user)
+        with patch(self.RESOLVE, return_value=Response(status=status.HTTP_200_OK)) as resolve:
+            return client.get(url, {'fileuri': self.FILEURI}), resolve
+
+    @pytest.mark.django_db
+    def test_task_resolve_is_not_reachable_from_another_organization(self):
+        task = TaskFactory(project=ProjectFactory())
+        attacker = OrganizationFactory().created_by
+
+        response, resolve = self._get(attacker, f'/tasks/{task.id}/resolve/')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        resolve.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_project_resolve_is_not_reachable_from_another_organization(self):
+        project = ProjectFactory()
+        attacker = OrganizationFactory().created_by
+
+        response, resolve = self._get(attacker, f'/projects/{project.id}/resolve/')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        resolve.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_task_resolve_still_reaches_resolution_inside_the_owning_organization(self):
+        project = ProjectFactory()
+        task = TaskFactory(project=project)
+
+        response, resolve = self._get(project.organization.created_by, f'/tasks/{task.id}/resolve/')
+
+        assert response.status_code == status.HTTP_200_OK
+        resolve.assert_called_once()
+
+    @pytest.mark.django_db
+    def test_project_resolve_still_reaches_resolution_inside_the_owning_organization(self):
+        project = ProjectFactory()
+
+        response, resolve = self._get(project.organization.created_by, f'/projects/{project.id}/resolve/')
+
+        assert response.status_code == status.HTTP_200_OK
+        resolve.assert_called_once()


### PR DESCRIPTION
Fixes #9924.

## Problem

`GET /tasks/<task_id>/resolve/` and `GET /projects/<project_id>/resolve/` fetch the object by bare primary key:

```python
task = Task.objects.get(pk=task_id)
project = Project.objects.get(pk=project_id)
```

Neither is scoped to an organization, so the only tenant check is `ResolveStorageUriAPIMixin.resolve` calling `instance.has_permission(request.user)`, which reaches `ProjectMixin.has_permission`:

```python
return not (self.organization_id and self.organization.has_deleted(user))
```

`Organization.has_deleted` matches an `OrganizationMember` row with `deleted_at` set. That is true for a membership someone had and lost, and false for a user who was never a member at all, so the check rejects ex-members and admits strangers. `Organization.has_permission`, defined a few lines below it, is the one that requires an active membership.

The result is that any authenticated user can pass another organization's task or project id and have Label Studio presign or proxy the file from that tenant's connected storage. Ids are sequential, so the set is walkable. The code comment on that permission check explains the assumption it was written under: "LSO always runs a single organization, so cross-org access does not exist by design."

## Change

Both lookups now carry the organization, matching how the task and project list endpoints already scope their querysets (`tasks/api.py`, `projects/api.py`). A cross-organization id returns 404 and never reaches storage resolution.

## Tests

`TestResolveStorageUriCrossOrganization` in `label_studio/io_storages/tests/test_proxy_api.py`, four cases: an outside organization is refused on both endpoints, and a member of the owning organization still reaches resolution on both. They patch `ResolveStorageUriAPIMixin.resolve` and assert on whether it is reached, because a 404 alone does not separate "not your tenant" from "no storage configured for that URI".

Both refusal tests fail against the current code and pass with this change. The two same-organization tests pass either way, so they pin that the scope does not over-block.

Two existing tests asserted the exact lookup call (`assert_called_once_with(pk=1)`), which is the thing this changes, so they now assert the organization is part of it.

    pytest label_studio/io_storages/tests/test_proxy_api.py     41 passed (37 before this change, plus 4 new)
    pytest label_studio/io_storages/                            199 passed
    pytest label_studio/tasks/tests/test_api.py -k resolve      4 passed
    ruff check / ruff format                                    clean

## Validated against the reporter's PoC

`poc_cross_org_idor.py` from #9924, run against this branch and against the same tree with the fix reverted. Two lines changed, the repo path and the response read described below, nothing in the attack itself:

| | fix reverted | with fix |
| --- | --- | --- |
| attacker org == victim org | False | False |
| referenced file | status=200 leaked=True | status=404 leaked=False |
| arbitrary unreferenced key | status=200 leaked=True | status=404 leaked=False |

The reverted column reproduces the reporter's published output exactly. This is a stronger check than the unit tests, which assert on whether resolution is reached: the PoC mocks the storage stream and confirms the bytes themselves come back to the attacker.

One note for anyone else validating with it. The script reads the response as `resp.streaming_content if hasattr(...) else resp.content`, which works on the vulnerable path because that returns a streaming response, but raises `ContentNotRenderedError` on a patched build, where a 404 DRF `Response` has not been rendered yet. Calling `resp.render()` first is enough. As published it cannot report a successful fix, it throws instead.

The PoC also confirms the arbitrary-key behaviour described below: an unreferenced key in the same bucket returned 200 with data before this change. Organization scoping closes that across tenants, not within one.

## Acceptance criteria

1. In organization A, create a project with a cloud storage connection and import a task whose data references a file in that bucket.
2. As a user of organization A, open the task in the labeling view. The media loads as before.
3. Note the task id and the project id from organization A.
4. Sign in as a user of organization B who has never been a member of organization A.
5. Request `GET /tasks/<task_id_from_A>/resolve/?fileuri=<base64 of the file URI>`. Expect 404. Before this change it presigned or proxied the file.
6. Request `GET /projects/<project_id_from_A>/resolve/?fileuri=<same>`. Expect 404.
7. Confirm no regression for a removed member: a user whose membership in organization A was revoked still gets a non-200, as before.

## Not covered here

The report also notes that `can_resolve_url` checks only the scheme and bucket of the supplied `fileuri`, not that the key is one the task actually references, so a user inside the owning organization can still read unrelated objects from that bucket. That is a different trust boundary and a larger change, so it is left for a follow-up rather than mixed into this fix.
