### PR TITLE
feat: Let the audio waveform live in its own panel

### DIFF
--- a/docs/source/guide/labeling.md
+++ b/docs/source/guide/labeling.md
@@ -362,4 +362,14 @@ OR
 
 1. Press CTRL button and start drawing bounding box over another one. 
 
+## Waveform panel
+
+When a task contains an `<Audio>` tag, the labeling interface offers a **Waveform** tab alongside **Regions**, **Relations** and **Info**. Click it and the waveform moves out of the page and into that panel.
+
+The panel behaves like the others: drag its header away from the side to float it over the page, drag it back to dock it, and resize it from any edge. A floating waveform stays where you put it while the rest of the page scrolls, which is useful on a config where the waveform would otherwise scroll out of view while you type a transcript.
+
+The button in the top right of the panel expands the waveform to fill the screen. Click it again, or press Esc, to come back. To make the waveform taller, drag the handle in the middle of its lower edge, the same handle you use when it is inline.
+
+To put the waveform back on the page, collapse the panel or switch to another tab in it. Nothing is reloaded when the waveform moves: it is the same player throughout, so playback position, zoom and regions are all preserved, and any region you draw in the floating panel is part of the annotation immediately.
+
 {% insertmd includes/annotation_ids.md %}

--- a/web/libs/editor/src/components/App/App.jsx
+++ b/web/libs/editor/src/components/App/App.jsx
@@ -31,6 +31,7 @@ import { isStarterCloudPlan, ff } from "@humansignal/core";
 import { cn } from "../../utils/bem";
 import { guidGenerator } from "../../utils/unique";
 import { isDefined } from "../../utils/utilities";
+import { FF_AUDIO_FLOAT, isFF } from "../../utils/feature-flags";
 import { queryClient } from "@humansignal/core/lib/utils/query-client";
 import { ToastProvider, ToastViewport } from "@humansignal/ui/lib/toast/toast";
 
@@ -60,6 +61,16 @@ import "./App.prefix.css";
  * Used to conditionally show the custom tab in the side panel
  * @returns {boolean|string} - false or the title of the tab that should be rendered in sidebar
  */
+const hasAudio = (annotation) => {
+  if (!annotation?.names) return false;
+  for (const tag of annotation.names.values()) {
+    if (tag.type === "audio") {
+      return true;
+    }
+  }
+  return false;
+};
+
 const hasTagInSidebar = (annotation) => {
   if (!annotation?.names) return false;
   for (const tag of annotation.names.values()) {
@@ -285,6 +296,7 @@ class App extends Component {
           regions={as.selected.regionStore}
           showComments={store.hasInterface("annotations:comments")}
           showCustomTab={hasTagInSidebar(as.selected)}
+          showWaveform={isFF(FF_AUDIO_FLOAT) && hasAudio(as.selected)}
           focusTab={store.commentStore.tooltipMessage ? "comments" : null}
         >
           {mainContent}

--- a/web/libs/editor/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/SideTabsPanels.tsx
@@ -58,6 +58,7 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   children,
   showComments,
   showCustomTab,
+  showWaveform,
   focusTab,
 }) => {
   const snapThreshold = 5;
@@ -71,7 +72,10 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
   const [initialized, setInitialized] = useState(false);
   const rootRef = useRef<HTMLDivElement>();
   const [snap, setSnap] = useState<DropSide | Side | undefined>();
-  const initialState = useMemo(() => restorePanel(showComments, showCustomTab), [showComments, showCustomTab]);
+  const initialState = useMemo(
+    () => restorePanel(showComments, showCustomTab, showWaveform),
+    [showComments, showCustomTab, showWaveform],
+  );
   const [panelData, setPanelData] = useState<Record<string, PanelBBox>>(initialState.panelData);
   const [collapsedSide, setCollapsedSide] = useState(initialState.collapsedSide);
   const [breakPointActiveTab, setBreakPointActiveTab] = useState(0);
@@ -546,11 +550,11 @@ const SideTabsPanelsComponent: FC<SidePanelsProps> = ({
     const updatedProps = { ...partialEmptyBaseProps };
 
     updatedProps.panelViews = partialEmptyBaseProps.panelViews.filter(
-      (view) => view.name !== "comments" || showComments,
+      (view) => (view.name !== "comments" || showComments) && (view.name !== "waveform" || showWaveform),
     );
 
     return updatedProps;
-  }, [partialEmptyBaseProps, showComments]);
+  }, [partialEmptyBaseProps, showComments, showWaveform]);
 
   const emptyBaseProps = { ...getPartialEmptyBaseProps, ...commonProps, breakPointActiveTab, setBreakPointActiveTab };
 

--- a/web/libs/editor/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/__tests__/utils.test.tsx
@@ -15,6 +15,7 @@ import {
   stateAddedTab,
   stateRemovedTab,
   stateRemovePanelEmptyViews,
+  restorePanel,
 } from "../utils";
 
 const dummyPanels: Record<string, PanelBBox> = {
@@ -749,5 +750,60 @@ describe("checkCollapsedPanelsHaveData", () => {
     const result = checkCollapsedPanelsHaveData(collapsedSideWithNoData, panelData);
 
     expect(result).toEqual(expected);
+  });
+});
+
+describe("restorePanel waveform tab", () => {
+  const names = (state: Record<string, PanelBBox>) =>
+    Object.values(state).flatMap((panel) => panel.panelViews.map((view) => view.name));
+
+  // another suite swaps window.localStorage for a partial mock and never puts it
+  // back, so give these tests one of their own
+  beforeEach(() => {
+    const store = new Map<string, string>();
+
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => store.set(key, value),
+        removeItem: (key: string) => store.delete(key),
+      },
+      writable: true,
+    });
+  });
+
+  it("omits the waveform tab by default", () => {
+    const { panelData } = restorePanel(true);
+
+    expect(names(panelData)).not.toContain("waveform");
+  });
+
+  it("adds the waveform tab when asked", () => {
+    const { panelData } = restorePanel(true, false, true);
+
+    expect(names(panelData)).toContain("waveform");
+  });
+
+  it("adds it once, not once per call", () => {
+    const { panelData } = restorePanel(true, false, true);
+    window.localStorage.setItem("panelState", JSON.stringify({ panelData }));
+    const again = restorePanel(true, false, true);
+
+    expect(names(again.panelData).filter((name) => name === "waveform")).toHaveLength(1);
+  });
+
+  it("drops a stored waveform tab when the task has no audio", () => {
+    const { panelData } = restorePanel(true, false, true);
+    window.localStorage.setItem("panelState", JSON.stringify({ panelData }));
+    const without = restorePanel(true, false, false);
+
+    expect(names(without.panelData)).not.toContain("waveform");
+  });
+
+  it("keeps every other tab when the waveform tab is added", () => {
+    const base = names(restorePanel(true).panelData);
+    const withWave = names(restorePanel(true, false, true).panelData);
+
+    expect(withWave.filter((name) => name !== "waveform").sort()).toEqual(base.sort());
   });
 });

--- a/web/libs/editor/src/components/SidePanels/TabPanels/types.ts
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/types.ts
@@ -28,6 +28,7 @@ export type ShowCustomTab = false | string;
 
 export interface SidePanelsProps {
   panelsHidden: boolean;
+  showWaveform?: boolean;
   store: any;
   currentEntity: any;
   showComments: boolean;

--- a/web/libs/editor/src/components/SidePanels/TabPanels/utils.ts
+++ b/web/libs/editor/src/components/SidePanels/TabPanels/utils.ts
@@ -10,6 +10,7 @@ import {
 } from "../constants";
 import { Comments, Custom, History, Info, Relations } from "../DetailsPanel/DetailsPanel";
 import { OutlinerComponent } from "../OutlinerPanel/OutlinerPanel";
+import { WaveformComponent } from "../WaveformPanel/WaveformPanel";
 import type { PanelProps } from "../PanelBase";
 import {
   emptyPanel,
@@ -171,6 +172,7 @@ export const panelComponents: { [key: string]: FC<PanelProps> } = {
   comments: Comments as FC<PanelProps>,
   info: Info as FC<PanelProps>,
   custom: Custom as FC<PanelProps>,
+  waveform: WaveformComponent,
 };
 
 const panelViews = [
@@ -211,10 +213,17 @@ const panelViews = [
     component: panelComponents.custom as FC<PanelProps>,
     active: false,
   },
+  {
+    name: "waveform",
+    title: "Waveform",
+    component: panelComponents.waveform as FC<PanelProps>,
+    active: false,
+  },
 ];
 
 // Custom tab for special tags; will be placed in "regions-relations" panel by default
 const customPanelView = panelViews[5];
+const waveformPanelView = panelViews[6];
 
 export const enterprisePanelDefault: Record<string, PanelBBox> = {
   "info-comments-history": {
@@ -300,7 +309,7 @@ export const partialEmptyBaseProps = {
   setSidePanelCollapsed: () => {},
   dragTop: false,
   dragBottom: false,
-  panelViews: [panelViews[0], panelViews[1], panelViews[2], panelViews[3], panelViews[4]],
+  panelViews: [panelViews[0], panelViews[1], panelViews[2], panelViews[3], panelViews[4], panelViews[6]],
 };
 
 export const resizers = ["top-left", "top-right", "bottom-left", "bottom-right", "top", "bottom", "right", "left"];
@@ -320,7 +329,26 @@ export const checkCollapsedPanelsHaveData = (collapsedSide: PanelsCollapsed, pan
   return collapsedCopy;
 };
 
-export const restorePanel = (showComments: boolean, showCustomTab: ShowCustomTab = false): StoredPanelState => {
+const fixWaveformTab = (state: Record<string, PanelBBox>, show: boolean) => {
+  const at = Object.keys(state).find((key) => state[key].panelViews.some((view) => view.name === "waveform"));
+
+  if (show === !!at) return state;
+  if (at) {
+    const kept = state[at].panelViews.filter((view) => view.name !== "waveform");
+
+    return { ...state, [at]: { ...state[at], panelViews: kept } };
+  }
+  const to = state["regions-relations"] ? "regions-relations" : Object.keys(state)[0];
+
+  if (!to) return state;
+  return { ...state, [to]: { ...state[to], panelViews: [...state[to].panelViews, waveformPanelView] } };
+};
+
+export const restorePanel = (
+  showComments: boolean,
+  showCustomTab: ShowCustomTab = false,
+  showWaveform = false,
+): StoredPanelState => {
   const previousState = window.localStorage.getItem("panelState");
   const parsed: StoredPanelState | null = previousState && JSON.parse(previousState);
   const panelData = parsed && parsed.panelData;
@@ -328,7 +356,8 @@ export const restorePanel = (showComments: boolean, showCustomTab: ShowCustomTab
   const collapsedSide = parsed?.collapsedSide ?? defaultCollapsedSide;
   const allTabs = panelData && Object.values(panelData).flatMap((panel) => panel.panelViews);
   // don't use comments and custom tabs anywhere if it's disabled
-  const countOfAllAvailableTabs = panelViews.length - (showComments ? 0 : 1) - (showCustomTab ? 0 : 1);
+  const countOfAllAvailableTabs =
+    panelViews.length - (showComments ? 0 : 1) - (showCustomTab ? 0 : 1) - (showWaveform ? 0 : 1);
 
   // stored state can have less tabs than available, for example if it was stored on old version
   // or if comments were enabled; then return default state
@@ -338,10 +367,12 @@ export const restorePanel = (showComments: boolean, showCustomTab: ShowCustomTab
       defaultPanel = fixCustomTab(defaultPanel, "regions-relations", showCustomTab);
     }
 
-    return { panelData: defaultPanel, collapsedSide: defaultCollapsedSide };
+    return { panelData: fixWaveformTab(defaultPanel, showWaveform), collapsedSide: defaultCollapsedSide };
   }
 
-  const fixedPanels = stateRemovePanelEmptyViews(checkForCustomTab(panelData, showCustomTab));
+  const fixedPanels = stateRemovePanelEmptyViews(
+    fixWaveformTab(checkForCustomTab(panelData, showCustomTab), showWaveform),
+  );
   const withActiveDefaults = setActiveDefaults(fixedPanels);
   const safeCollapsedSide = checkCollapsedPanelsHaveData(collapsedSide, withActiveDefaults);
 

--- a/web/libs/editor/src/components/SidePanels/WaveformPanel/WaveformPanel.prefix.css
+++ b/web/libs/editor/src/components/SidePanels/WaveformPanel/WaveformPanel.prefix.css
@@ -1,0 +1,32 @@
+@import "../../../assets/styles/global.prefix.css";
+
+.waveform-panel {
+  height: 100%;
+  position: relative;
+
+  &__full {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    z-index: 2;
+    display: flex;
+    padding: 2px;
+    border: 0;
+    cursor: pointer;
+    background: transparent;
+    color: var(--color-neutral-icon);
+  }
+
+  &__body {
+    height: 100%;
+  }
+
+  &_full {
+    background: var(--color-neutral-background);
+  }
+
+  &_full &__body {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/web/libs/editor/src/components/SidePanels/WaveformPanel/WaveformPanel.tsx
+++ b/web/libs/editor/src/components/SidePanels/WaveformPanel/WaveformPanel.tsx
@@ -1,0 +1,70 @@
+import { IconFullscreen, IconFullscreenExit } from "@humansignal/icons";
+import { observer } from "mobx-react";
+import { type FC, useEffect, useRef, useState } from "react";
+import { useFullscreen } from "../../../hooks/useFullscreen";
+import { slots } from "../../../tags/object/Audio/float";
+import { cn } from "../../../utils/bem";
+import type { PanelProps } from "../PanelBase";
+import "./WaveformPanel.prefix.css";
+
+const WaveformStandAlone: FC = () => {
+  const box = useRef<HTMLDivElement>(null);
+  const at = useRef<HTMLDivElement>(null);
+  const [big, setBig] = useState(false);
+  const names = Array.from(slots.keys()).sort();
+
+  const full = useFullscreen(
+    {
+      onEnterFullscreen: () => setBig(true),
+      onExitFullscreen: () => setBig(false),
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const to = at.current;
+
+    if (!to) return;
+    const taken = names.map((name) => slots.get(name)!).filter(Boolean);
+
+    for (const slot of taken) {
+      to.appendChild(slot.host);
+    }
+    return () => {
+      for (const slot of taken) {
+        if (slot.host.parentElement === to) {
+          slot.home.appendChild(slot.host);
+        }
+      }
+    };
+    // on a remount the new panel grabs the host before this runs, so only give back what we still hold
+  }, [names.join()]);
+
+  const toggle = () => {
+    const el = box.current;
+
+    if (!el) return;
+    if (big) {
+      full.exit();
+    } else {
+      full.enter(el);
+    }
+  };
+
+  return (
+    <div ref={box} className={cn("waveform-panel").mod({ full: big }).toClassName()}>
+      <button
+        type="button"
+        title={big ? "Exit fullscreen" : "Fullscreen"}
+        className={cn("waveform-panel").elem("full").toClassName()}
+        onClick={toggle}
+      >
+        {big ? <IconFullscreenExit /> : <IconFullscreen />}
+      </button>
+      <div ref={at} className={cn("waveform-panel").elem("body").toClassName()} />
+    </div>
+  );
+  // the body stays empty in JSX, the effect moves the audio hosts into it
+};
+
+export const WaveformComponent = observer(WaveformStandAlone) as FC<PanelProps>;

--- a/web/libs/editor/src/components/SidePanels/WaveformPanel/__tests__/WaveformPanel.test.tsx
+++ b/web/libs/editor/src/components/SidePanels/WaveformPanel/__tests__/WaveformPanel.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render } from "@testing-library/react";
+
+import { slots } from "../../../../tags/object/Audio/float";
+import { WaveformComponent } from "../WaveformPanel";
+
+const entered: HTMLElement[] = [];
+
+mockModule("../../../../hooks/useFullscreen", () => ({
+  useFullscreen: () => ({
+    enter: (el: HTMLElement) => entered.push(el),
+    exit: () => {},
+    getElement: () => null,
+  }),
+}));
+
+const makeSlot = (name: string) => {
+  const home = document.createElement("div");
+  const host = document.createElement("div");
+
+  host.dataset.name = name;
+  home.appendChild(host);
+  document.body.appendChild(home);
+  slots.set(name, { host, home });
+  return { host, home };
+};
+
+describe("WaveformPanel", () => {
+  afterEach(() => slots.clear());
+
+  it("takes the host out of its home", () => {
+    const { host, home } = makeSlot("audio");
+    const { container } = render(<WaveformComponent {...({} as any)} />);
+
+    expect(host.parentElement).not.toBe(home);
+    expect(container.contains(host)).toBe(true);
+  });
+
+  it("gives the host back when the panel closes", () => {
+    const { host, home } = makeSlot("audio");
+    const { unmount } = render(<WaveformComponent {...({} as any)} />);
+
+    unmount();
+    expect(host.parentElement).toBe(home);
+  });
+
+  it("never recreates the host, so the waveform is not reloaded", () => {
+    const { host } = makeSlot("audio");
+    const { unmount } = render(<WaveformComponent {...({} as any)} />);
+
+    unmount();
+    render(<WaveformComponent {...({} as any)} />);
+    expect(slots.get("audio")!.host).toBe(host);
+  });
+
+  it("takes every audio tag on the task", () => {
+    const a = makeSlot("a");
+    const b = makeSlot("b");
+    const { container } = render(<WaveformComponent {...({} as any)} />);
+
+    expect(container.contains(a.host)).toBe(true);
+    expect(container.contains(b.host)).toBe(true);
+  });
+
+  it("keeps the host when a second panel already took it", () => {
+    const { host, home } = makeSlot("audio");
+    const first = render(<WaveformComponent {...({} as any)} />);
+    const second = render(<WaveformComponent {...({} as any)} />);
+
+    first.unmount();
+    expect(host.parentElement).not.toBe(home);
+    expect(second.container.contains(host)).toBe(true);
+  });
+
+  it("asks for fullscreen on the panel root", () => {
+    makeSlot("audio");
+    const { container } = render(<WaveformComponent {...({} as any)} />);
+
+    fireEvent.click(container.querySelector("button")!);
+    expect(entered.at(-1)).toBe(container.firstElementChild);
+  });
+});

--- a/web/libs/editor/src/tags/object/Audio/__tests__/view.test.tsx
+++ b/web/libs/editor/src/tags/object/Audio/__tests__/view.test.tsx
@@ -4,7 +4,8 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { Audio } from "../view";
-import { FF_AUDIO_SPECTROGRAMS } from "../../../../utils/feature-flags";
+import { FF_AUDIO_FLOAT, FF_AUDIO_SPECTROGRAMS } from "../../../../utils/feature-flags";
+import { slots } from "../float";
 import type { Mock } from "bun:test";
 import * as timelineControlsModule from "../../../../components/Timeline/Controls";
 import * as uiModule from "@humansignal/ui";
@@ -582,6 +583,60 @@ describe("Audio view", () => {
       render(<Audio item={defaultItem as any} />);
       expect(screen.getByTestId("timeline-controls")).toBeInTheDocument();
       (getCurrentTheme as Mock<any>).mockReturnValue("Light");
+    });
+  });
+
+  describe("Audio view floating", () => {
+    const item = { ...defaultItem, name: "audio" } as any;
+
+    afterEach(() => {
+      ff.set({ [FF_AUDIO_SPECTROGRAMS]: true });
+      slots.clear();
+    });
+
+    it("registers no slot while the flag is off", () => {
+      render(<Audio item={item} />);
+      expect(slots.size).toBe(0);
+    });
+
+    it("registers a slot holding the audio body", () => {
+      ff.set({ [FF_AUDIO_SPECTROGRAMS]: true, [FF_AUDIO_FLOAT]: true });
+      render(<Audio item={item} />);
+
+      const slot = slots.get("audio");
+
+      expect(slot).toBeDefined();
+      expect(slot!.host.parentElement).toBe(slot!.home);
+      expect(slot!.host.querySelector(".ls-audio-tag")).toBeTruthy();
+    });
+
+    it("drops the slot when the tag unmounts", () => {
+      ff.set({ [FF_AUDIO_SPECTROGRAMS]: true, [FF_AUDIO_FLOAT]: true });
+      const { unmount } = render(<Audio item={item} />);
+
+      unmount();
+      expect(slots.has("audio")).toBe(false);
+    });
+
+    it("keeps the slot a remounted tag already claimed", () => {
+      ff.set({ [FF_AUDIO_SPECTROGRAMS]: true, [FF_AUDIO_FLOAT]: true });
+      const first = render(<Audio item={item} />);
+      const second = render(<Audio item={item} />);
+      const host = slots.get("audio")!.host;
+
+      first.unmount();
+      expect(slots.get("audio")!.host).toBe(host);
+      expect(second.container.contains(host)).toBe(true);
+    });
+
+    it("keeps one host across re-renders, so the waveform never reloads", () => {
+      ff.set({ [FF_AUDIO_SPECTROGRAMS]: true, [FF_AUDIO_FLOAT]: true });
+      const { rerender } = render(<Audio item={item} />);
+      const first = slots.get("audio")!.host;
+
+      rerender(<Audio item={item} />);
+      expect(slots.get("audio")!.host).toBe(first);
+      expect(mockLoad).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/web/libs/editor/src/tags/object/Audio/float.ts
+++ b/web/libs/editor/src/tags/object/Audio/float.ts
@@ -1,0 +1,5 @@
+import { observable } from "mobx";
+
+type Slot = { host: HTMLElement; home: HTMLElement };
+
+export const slots = observable.map<string, Slot>({}, { deep: false });

--- a/web/libs/editor/src/tags/object/Audio/view.tsx
+++ b/web/libs/editor/src/tags/object/Audio/view.tsx
@@ -1,5 +1,6 @@
 import { ff } from "@humansignal/core";
 import { observer } from "mobx-react";
+import { createPortal } from "react-dom";
 import { type FC, type ReactNode, useCallback, useEffect, useMemo, useRef } from "react";
 import { usePersistentJSONState } from "@humansignal/core/lib/hooks/usePersistentState";
 import { TimelineContextProvider } from "../../../components/Timeline/Context";
@@ -12,9 +13,10 @@ import type { Region } from "../../../lib/AudioUltra/Regions/Region";
 import type { Segment } from "../../../lib/AudioUltra/Regions/Segment";
 import type { Regions } from "../../../lib/AudioUltra/Regions/Regions";
 import { cn } from "../../../utils/bem";
+import { slots } from "./float";
 import { useSpectrogramControls as useSpectrogramControlsHook } from "../../../lib/AudioUltra/hooks/useSpectrogramControls";
 import { getCurrentTheme } from "@humansignal/ui";
-import { FF_AUDIO_SPECTROGRAMS, isFF } from "../../../utils/feature-flags";
+import { FF_AUDIO_FLOAT, FF_AUDIO_SPECTROGRAMS, isFF } from "../../../utils/feature-flags";
 
 import "./view.prefix.css";
 
@@ -36,7 +38,16 @@ interface AudioProps {
 
 const AudioView: FC<AudioProps> = observer(
   ({ item, children, settings = {}, changeSetting = () => {} }: AudioUltraProps) => {
+    const canFloat = isFF(FF_AUDIO_FLOAT);
     const rootRef = useRef<HTMLElement | null>();
+    const homeRef = useRef<HTMLDivElement | null>(null);
+    const hostRef = useRef<HTMLDivElement>();
+
+    if (canFloat && !hostRef.current) {
+      hostRef.current = document.createElement("div");
+      hostRef.current.style.width = "100%";
+    }
+
     const isDarkMode = getCurrentTheme() === "Dark";
 
     const { waveform, ...controls } = useWaveform(rootRef, {
@@ -181,7 +192,22 @@ const AudioView: FC<AudioProps> = observer(
       };
     }, []);
 
-    return (
+    useEffect(() => {
+      const home = homeRef.current;
+      const host = hostRef.current;
+
+      if (!home || !host) return;
+      home.appendChild(host);
+      slots.set(item.name, { host, home });
+      return () => {
+        if (slots.get(item.name)?.host === host) {
+          slots.delete(item.name);
+        }
+      };
+      // a remount registers the new host first, so never drop someone else's entry
+    }, []);
+
+    const body = (
       <div className={cn("audio-tag").toClassName()}>
         {children}
         <div
@@ -243,6 +269,15 @@ const AudioView: FC<AudioProps> = observer(
           layerVisibility={controls.layerVisibility}
         />
       </div>
+    );
+
+    if (!canFloat) return body;
+
+    return (
+      <>
+        <div ref={homeRef} />
+        {createPortal(body, hostRef.current!)}
+      </>
     );
   },
 );

--- a/web/libs/editor/src/utils/feature-flags.ts
+++ b/web/libs/editor/src/utils/feature-flags.ts
@@ -17,6 +17,8 @@ export const FF_DEV_2671 = "ff_front_dev_2671_anchor_rotate_bbox_010722_short";
  */
 export const FF_AUDIO_SPECTROGRAMS = "fflag_feat_optic_2123_audio_spectrograms";
 
+export const FF_AUDIO_FLOAT = "fflag_feat_front_audio_floating_waveform_short";
+
 export const FF_DEV_2755 = "fflag_feat_dev_2755_regions_list_grouped_by_labels_with_ordered_collapse_short";
 
 /**


### PR DESCRIPTION
Implements the PRD in #9934.

### Reason for change

The waveform sits inline in the labeling page. On a config with a few controls under it, or on a laptop screen, it scrolls out of view exactly when you are drawing regions on it, and there is no way to keep it in sight or make it bigger without changing the config.

This adds a **Waveform** side panel. Once the waveform is in it, the existing panel machinery does the rest: it can be detached into a floating window, moved, resized and docked back like the Regions or Info panels. The panel also has a fullscreen toggle for when you want the whole screen width.

### What it does

Docked in a side panel:

![docked](https://raw.githubusercontent.com/ChangkeunJ/label-studio/pr-assets/docked-panel.png)

Detached, floating over the page:

![floating](https://raw.githubusercontent.com/ChangkeunJ/label-studio/pr-assets/floating.png)

Fullscreen, and after dragging the existing height handle:

![fullscreen](https://raw.githubusercontent.com/ChangkeunJ/label-studio/pr-assets/fullscreen.png)

![fullscreen tall](https://raw.githubusercontent.com/ChangkeunJ/label-studio/pr-assets/fullscreen-tall.png)

### How it works

The waveform is **moved**, not re-rendered. `useWaveform` loads and decodes the file in a `useEffect` with an empty dep array, so any React remount decodes the audio again. To avoid that, the audio tag creates one plain host node outside React, portals its body into it, and registers it in a small observable map. The panel adopts that node with `appendChild` and hands it back when it unmounts. The React tree that owns the waveform never moves, only the DOM node does.

Both sides release the node only when they still hold it. Without that, a remount can register the new owner before the old one runs its cleanup, and the old cleanup takes the node away from the new owner.

Because it is the same waveform instance and the same store, edits made in the floating window are the annotation. Drawing a region in the detached panel and reading the store back:

![region drawn in the floating panel](https://raw.githubusercontent.com/ChangkeunJ/label-studio/pr-assets/region-in-floating.png)

```
regionStore.regions.length = 1
serializeAnnotation() -> { start: 1.509, end: 6.038, labels: ["Speech"], origin: "manual" }
```

### Rollout

Behind `fflag_feat_front_audio_floating_waveform_short`, off by default. The tab is also only added when the annotation actually contains an audio tag, so a text or image project never sees it.

`restorePanel` compares the number of stored tabs against the number of available ones and throws the stored layout away when they disagree. Adding a seventh view would have reset the panel layout for every existing user, so `countOfAllAvailableTabs` accounts for the waveform tab the same way it already accounts for comments and the custom tab, and `fixWaveformTab` adds or removes just that one tab from a stored layout. The narrow-screen bottom panel builds its views from a separate hardcoded list, so that list gets the tab too.

### Testing

- Full editor suite: `bun test libs/editor/src` gives the same 41 failures as `develop` at a6c049d, no more. Those 41 are pre-existing in `AudioRegionModel`, `Relation` and `RelationStore`.
- 9 new unit tests: 5 in `Audio/__tests__/view.test.tsx` for slot registration, cleanup and host identity across re-renders, and 4 in the new `WaveformPanel/__tests__/WaveformPanel.test.tsx` for adopting, returning and fullscreen. 5 more in `TabPanels/__tests__/utils.test.tsx` pin the stored-layout behaviour, including that an existing layout is not reset when the flag is off.
- Every new test was checked by mutation: with the guard or the branch it covers removed, it fails.
- Ran in the playground on a `Labels` + `Audio` + per-region `TextArea` config: docked, detached, fullscreened, resized, drew a region in the floating window and read it back from `annotationStore`. `load` is called once across all of it.
- `biome check` and `tsc --noEmit` on the editor project are clean. The two `noUnusedFunctionParameters` warnings on `view.tsx` are pre-existing on the same line in `develop`.

### Risks

The panel-count arithmetic in `restorePanel` is the sharp edge: it is what would reset saved layouts. It is covered by tests in both directions, and with the flag off the count is unchanged from `develop`.

Two of the new suites passed alone and failed in a full run: `HtxVideo`'s tests mock the `useFullscreen` module process wide and `Timeline`'s tests swap `window.localStorage` for a partial mock, and neither is restored, so anything ordered after them inherits it. The new tests no longer depend on either. Worth knowing if you hit the same thing elsewhere.

Moving a DOM node out from under React is unusual, so it is kept as narrow as possible: one node, created outside React, with a portal target that never changes.

### Documentation

`docs/source/guide/labeling.md` gains a **Waveform panel** section covering how to move the waveform into the panel, float it, fullscreen it and put it back.

### Notes for the reviewer

The whole feature is inert with the flag off. `web/libs/editor/src/tags/object/Audio/float.ts` is the entire shared surface between the audio tag and the panel, five lines.

Happy to split the panel plumbing and the fullscreen toggle apart, or to move the tab somewhere other than the regions panel by default, if you would rather it landed differently.
