### PR TITLE
feat: Add hotkeys for audio playback speed

### DIFF
--- a/web/libs/editor/src/core/settings/keymap.json
+++ b/web/libs/editor/src/core/settings/keymap.json
@@ -17,6 +17,14 @@
     "key": "alt+d",
     "description": "Go one step forward"
   },
+  "audio:speed-down": {
+    "key": "alt+[",
+    "description": "Decrease playback speed"
+  },
+  "audio:speed-up": {
+    "key": "alt+]",
+    "description": "Increase playback speed"
+  },
   "ts:grow-left": {
     "key": "left",
     "description": "Increase region to the left"

--- a/web/libs/editor/src/lib/AudioUltra/Controls/Player.ts
+++ b/web/libs/editor/src/lib/AudioUltra/Controls/Player.ts
@@ -6,6 +6,9 @@ import type { Waveform } from "../Waveform";
 
 const isSyncedBuffering = ff.isActive(ff.FF_SYNCED_BUFFERING);
 
+export const MIN_SPEED = 0.5;
+export const MAX_SPEED = 2.5;
+
 export abstract class Player extends Destructable {
   protected audio?: WaveformAudio;
   protected wf: Waveform;

--- a/web/libs/editor/src/lib/AudioUltra/react/ConfigControl.tsx
+++ b/web/libs/editor/src/lib/AudioUltra/react/ConfigControl.tsx
@@ -10,10 +10,9 @@ import "./ConfigControl.prefix.css";
 import { SpectrogramConfig } from "./SpectrogramConfig";
 import type { Waveform } from "../Waveform";
 import type { MutableRefObject } from "react";
+import { MAX_SPEED, MIN_SPEED } from "../Controls/Player";
 
-const MAX_SPEED = 2.5;
 const MAX_ZOOM = 150;
-const MIN_SPEED = 0.5;
 const MIN_ZOOM = 1;
 
 export interface ConfigControlProps {

--- a/web/libs/editor/src/tags/object/Audio/__tests__/view.test.tsx
+++ b/web/libs/editor/src/tags/object/Audio/__tests__/view.test.tsx
@@ -165,6 +165,7 @@ describe("Audio view", () => {
       const mockWaveform = {
         load: mockLoad,
         on: mockOn,
+        rate: 1,
         getLayer: mockGetLayer,
         seekBackward: mockSeekBackward,
         seekForward: mockSeekForward,
@@ -398,6 +399,55 @@ describe("Audio view", () => {
       expect(deleteAllCb).toBeDefined();
       deleteAllCb?.();
       expect(mockClearSegments).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("hotkey audio:speed-up and audio:speed-down", () => {
+    const renderAndGet = (name: string) => {
+      const { unmount } = render(<Audio item={defaultItem as any} />);
+      const hotkey = getLastHotkeyInstance();
+      const cb = (hotkey?.addNamed as Mock<any>)?.mock?.calls?.find((c: any[]) => c[0] === name)?.[1];
+      const wf = (audioUltraReactModule.useWaveform as Mock<any>).mock.results.at(-1)?.value?.waveform?.current;
+
+      return { cb, wf, unmount };
+    };
+
+    it("audio:speed-up steps the rate up by 0.1", () => {
+      const { cb, wf } = renderAndGet("audio:speed-up");
+
+      expect(cb).toBeDefined();
+      cb?.();
+      expect(wf.rate).toBe(1.1);
+    });
+
+    it("audio:speed-down steps the rate down by 0.1", () => {
+      const { cb, wf } = renderAndGet("audio:speed-down");
+
+      cb?.();
+      expect(wf.rate).toBe(0.9);
+    });
+
+    it("keeps the rate on the 0.1 grid across repeated steps", () => {
+      const { cb, wf } = renderAndGet("audio:speed-down");
+
+      cb?.();
+      cb?.();
+      cb?.();
+      // 1 - 0.1 - 0.1 - 0.1 is 0.7000000000000001 without rounding
+      expect(wf.rate).toBe(0.7);
+    });
+
+    it("clamps at the same bounds as the speed slider", () => {
+      const up = renderAndGet("audio:speed-up");
+
+      for (let i = 0; i < 30; i++) up.cb?.();
+      expect(up.wf.rate).toBe(2.5);
+      up.unmount();
+
+      const down = renderAndGet("audio:speed-down");
+
+      for (let i = 0; i < 30; i++) down.cb?.();
+      expect(down.wf.rate).toBe(0.5);
     });
   });
 

--- a/web/libs/editor/src/tags/object/Audio/view.tsx
+++ b/web/libs/editor/src/tags/object/Audio/view.tsx
@@ -7,7 +7,9 @@ import { ErrorMessage } from "../../../components/ErrorMessage/ErrorMessage";
 import { Controls } from "../../../components/Timeline/Controls";
 import type { TimelineSettings } from "../../../components/Timeline/Types";
 import { Hotkey } from "../../../core/Hotkey";
+import { clamp } from "../../../lib/AudioUltra/Common/Utils";
 import { useWaveform } from "../../../lib/AudioUltra/react";
+import { MAX_SPEED, MIN_SPEED } from "../../../lib/AudioUltra/Controls/Player";
 import type { Region } from "../../../lib/AudioUltra/Regions/Region";
 import type { Segment } from "../../../lib/AudioUltra/Regions/Segment";
 import type { Regions } from "../../../lib/AudioUltra/Regions/Regions";
@@ -20,6 +22,7 @@ import "./view.prefix.css";
 
 // Define Defaults
 const NORMALIZED_STEP = 0.1;
+const SPEED_STEP = 0.1;
 
 const isAudioSpectrograms = isFF(FF_AUDIO_SPECTROGRAMS);
 
@@ -175,6 +178,20 @@ const AudioView: FC<AudioProps> = observer(
       hotkeys.addNamed("region:delete-all", () => {
         waveform.current?.regions.clearSegments();
       });
+
+      const changeRate = (delta: number) => {
+        const wf = waveform.current;
+
+        if (!wf) return;
+        // keep the value on the same 0.1 grid the speed slider uses
+        const rate = Math.round((wf.rate + delta) * 10) / 10;
+
+        wf.rate = clamp(rate, MIN_SPEED, MAX_SPEED);
+      };
+
+      hotkeys.addNamed("audio:speed-up", () => changeRate(SPEED_STEP));
+
+      hotkeys.addNamed("audio:speed-down", () => changeRate(-SPEED_STEP));
 
       return () => {
         hotkeys.unbindAll();


### PR DESCRIPTION
### Reason for change

Playback speed is only reachable through the slider in the audio settings popover. While transcribing you end up opening the popover, dragging the slider, closing it, and doing it again a few seconds later. Every other transport control already has a hotkey.

`alt+[` and `alt+]` step the rate by 0.1, with the same 0.5 to 2.5 bounds the slider enforces, so the two controls cannot disagree.

### Implementation notes

`MIN_SPEED` and `MAX_SPEED` were defined in `ConfigControl.tsx`, which is a React component and drags a stylesheet in with it. They moved to `Player.ts`, which is where `rate` lives, and `ConfigControl` now imports them, so the popover and the hotkeys share one definition.

The step rounds back onto the 0.1 grid. Stepping down three times from 1 gives `0.7000000000000001` in plain floating point, which then shows up in the settings popover.

### Rollout

This is a small addition rather than a feature implementation, so there is no `prd:` issue for it; the larger waveform panel work it came out of is #9934. It is two new entries in `keymap.json`, which is also what puts them in the hotkeys help dialog.

### Testing

- 4 new tests in `Audio/__tests__/view.test.tsx`: up, down, the rounding across repeated steps, and clamping at both bounds.
- Each was checked by mutation: remove the rounding and the grid test fails, remove the `clamp` and the bounds test fails.
- Ran it in the playground against an audio config, watching the value in the settings popover follow the hotkeys.
- Full editor suite: `bun test libs/editor/src` gives the same 41 failures as `develop` at a6c049d, no more. Those 41 are pre-existing in `AudioRegionModel`, `Relation` and `RelationStore`.
- `biome check` and `tsc --noEmit` on the editor project are clean. The two `noUnusedFunctionParameters` warnings on `view.tsx` are pre-existing on the same line in `develop`.

### Risks

`[` and `]` with alt are not bound anywhere else in `keymap.json`. Nothing outside the audio tag changes behaviour; the only shared edit is moving two constants between modules.
