### PR TITLE
fix: preserve Data Manager summary results across lean refetches

### DIFF
--- a/web/libs/datamanager/src/mixins/DataStore/DataStore.js
+++ b/web/libs/datamanager/src/mixins/DataStore/DataStore.js
@@ -81,10 +81,18 @@ const MixinBase = types
     },
 
     setList({ list, total, reload, associatedList = [] }) {
-      const newEntity = list.map((t) => ({
-        ...t,
-        source: JSON.stringify(t),
-      }));
+      const newEntity = list.map((t) => {
+        // #9897: let the store preserve previously rendered values when a
+        // refetch returns unevaluated empties for them. Stores without the
+        // hook keep the previous replace behavior.
+        const existing = self.list.find((i) => i.id === t.id);
+        const merged = typeof self.mergeListItem === "function" ? self.mergeListItem(existing, t) : t;
+
+        return {
+          ...merged,
+          source: JSON.stringify(t),
+        };
+      });
 
       self.total = total;
 

--- a/web/libs/datamanager/src/mixins/DataStore/DataStore.test.js
+++ b/web/libs/datamanager/src/mixins/DataStore/DataStore.test.js
@@ -56,3 +56,71 @@ describe("DataStore.clear (FIT-2376)", () => {
     expect(dataStore.loading).toBe(true);
   });
 });
+
+describe("DataStore.setList mergeListItem hook (#9897)", () => {
+  let root;
+
+  afterEach(() => {
+    if (root) {
+      destroy(root);
+      root = null;
+    }
+  });
+
+  const SummaryItem = types.compose(
+    "SummaryTestItem",
+    DataStoreItem,
+    types.model({
+      id: types.identifierNumber,
+      annotations_results: types.optional(types.string, ""),
+      total_annotations: types.optional(types.number, 0),
+      predictions_results: types.optional(types.string, ""),
+      total_predictions: types.optional(types.number, 0),
+    }),
+  );
+
+  const HookedStore = DataStore("HookedDataStore", {
+    listItemType: SummaryItem,
+    apiMethod: "tasks",
+  }).actions((self) => ({
+    mergeListItem(existing, incoming) {
+      if (!existing) return incoming;
+      const out = { ...incoming };
+
+      if (out.annotations_results === "" && (out.total_annotations ?? 0) > 0 && existing.annotations_results) {
+        out.annotations_results = existing.annotations_results;
+      }
+      return out;
+    },
+  }));
+
+  const HookedRoot = types.model({
+    dataStore: types.optional(HookedStore, {}),
+  });
+
+  it("lets the store preserve previously fetched values when a refetch returns unevaluated empties", () => {
+    root = HookedRoot.create({});
+    const { dataStore } = root;
+
+    dataStore.setList({
+      list: [{ id: 1, annotations_results: "choice=positive", total_annotations: 1 }],
+      total: 1,
+      reload: true,
+    });
+    dataStore.setList({
+      list: [{ id: 1, annotations_results: "", total_annotations: 1 }],
+      total: 1,
+      reload: true,
+    });
+
+    expect(dataStore.list).toHaveLength(1);
+    expect(dataStore.list[0].annotations_results).toBe("choice=positive");
+  });
+
+  it("leaves list behavior unchanged when no hook is defined", () => {
+    root = Root.create({});
+    root.dataStore.setList({ list: [{ id: 7 }], total: 1, reload: true });
+    root.dataStore.setList({ list: [{ id: 7 }], total: 1, reload: true });
+    expect(root.dataStore.list).toHaveLength(1);
+  });
+});

--- a/web/libs/datamanager/src/stores/DataStores/__tests__/tasks.test.js
+++ b/web/libs/datamanager/src/stores/DataStores/__tests__/tasks.test.js
@@ -378,3 +378,67 @@ describe("tasks DataStore", () => {
     logSpy.mockRestore();
   });
 });
+
+describe("preserveUnevaluatedSummaries (#9897)", () => {
+  const { preserveUnevaluatedSummaries } = require("../tasks");
+
+  const cached = {
+    id: 1,
+    annotations_results: "choice=positive",
+    total_annotations: 1,
+    predictions_results: "choice=negative",
+    total_predictions: 1,
+  };
+
+  it("preserves cached summaries when a refetch returns unevaluated empties with positive counters", () => {
+    const out = preserveUnevaluatedSummaries(cached, {
+      id: 1,
+      annotations_results: "",
+      total_annotations: 1,
+      predictions_results: "",
+      total_predictions: 1,
+    });
+
+    expect(out.annotations_results).toBe("choice=positive");
+    expect(out.predictions_results).toBe("choice=negative");
+  });
+
+  it("blanks genuinely empty summaries when counters are zero", () => {
+    const out = preserveUnevaluatedSummaries(cached, {
+      id: 1,
+      annotations_results: "",
+      total_annotations: 0,
+      predictions_results: "",
+      total_predictions: 0,
+    });
+
+    expect(out.annotations_results).toBe("");
+    expect(out.predictions_results).toBe("");
+  });
+
+  it("takes fresh non-empty values over cached ones", () => {
+    const out = preserveUnevaluatedSummaries(cached, {
+      id: 1,
+      annotations_results: "choice=neutral",
+      total_annotations: 1,
+      predictions_results: "choice=neutral",
+      total_predictions: 1,
+    });
+
+    expect(out.annotations_results).toBe("choice=neutral");
+    expect(out.predictions_results).toBe("choice=neutral");
+  });
+
+  it("passes lean payloads through when nothing was cached", () => {
+    const incoming = { id: 2, annotations_results: "", total_annotations: 1 };
+
+    expect(preserveUnevaluatedSummaries(null, incoming)).toBe(incoming);
+    expect(preserveUnevaluatedSummaries({ id: 2 }, incoming).annotations_results).toBe("");
+  });
+
+  it("treats missing summary keys as unevaluated", () => {
+    const out = preserveUnevaluatedSummaries(cached, { id: 1, total_annotations: 1 });
+
+    expect(out.annotations_results).toBe("choice=positive");
+  });
+});

--- a/web/libs/datamanager/src/stores/DataStores/tasks.js
+++ b/web/libs/datamanager/src/stores/DataStores/tasks.js
@@ -16,6 +16,42 @@ const DM_USER_CHIP_COUNT_FIELDS = {
   reviewers_count: "reviewers",
   comment_authors_count: "comment_authors",
 };
+const DM_SUMMARY_RESULT_FIELDS = [
+  ["annotations_results", "total_annotations"],
+  ["predictions_results", "total_predictions"],
+];
+
+const isEmptySummaryValue = (value) => value === undefined || value === null || value === "";
+
+/**
+ * #9897: guard rendered summary columns against unevaluated refetch payloads.
+ * The list serializer emits `""` for summary fields the queryset did not
+ * evaluate, and `setList` used to replace rendered values with that `""`
+ * (e.g. returning from the labelling view blanks the Annotation Results
+ * column until an unrelated refetch repopulates it). `total_annotations > 0`
+ * next to `annotations_results === ""` is provably such an artifact — the
+ * counter only counts live annotations, so deletions zero it instead of
+ * leaving it positive. Genuine empties (counter at zero, fresh non-empty
+ * values, no cached value) all pass through untouched.
+ */
+export const preserveUnevaluatedSummaries = (existing, incoming) => {
+  if (!existing) return incoming;
+
+  const out = { ...incoming };
+
+  for (const [summaryField, countField] of DM_SUMMARY_RESULT_FIELDS) {
+    if (
+      isEmptySummaryValue(incoming[summaryField]) &&
+      Number(incoming[countField] ?? 0) > 0 &&
+      !isEmptySummaryValue(existing[summaryField])
+    ) {
+      out[summaryField] = existing[summaryField];
+    }
+  }
+
+  return out;
+};
+
 const fileAttributes = types.model({
   certainty: types.optional(types.maybeNull(types.number), 0),
   distance: types.optional(types.maybeNull(types.number), 0),
@@ -352,6 +388,10 @@ export const create = (columns) => {
         }
 
         return snapshot;
+      },
+
+      mergeListItem(existing, incoming) {
+        return preserveUnevaluatedSummaries(existing ? getSnapshot(existing) : null, incoming);
       },
 
       unsetTask() {


### PR DESCRIPTION
Fixes #9897.

## Problem
In the Data Manager grid, the Annotation Results column renders on first load but goes blank for every row after opening a task in the labelling view and navigating back. Any column resize makes the values reappear instantly.

## Root cause
The grid store is destroyed on unmount and rebuilt on return, so coming back always refetches the task list. The list serializer emits `""` for summary fields the queryset did not evaluate (`data_manager/serializers.py` `_pretty_results`), and the frontend `setList` replaced rendered values with that `""` wholesale (`web/libs/datamanager/src/mixins/DataStore/DataStore.js`). A resize triggers `view.save()` → list reload with the settled view, which is why values come back. Full chain in https://github.com/HumanSignal/label-studio/issues/9897#issuecomment-5625065842.

## Fix
- `DataStore.setList` now consults an optional per-store `mergeListItem(existing, incoming)` hook (stores without it keep exact previous behavior).
- `TasksStore.mergeListItem` preserves cached `annotations_results`/`predictions_results` only when the incoming value is empty (`""`/null/undefined) **and** the matching live counter (`total_annotations`/`total_predictions`, which exclude cancelled/deleted rows) is positive — provably an unevaluated payload, never a genuine deletion. Zero counters, fresh values, and first loads pass through untouched. Same preservation pattern as the existing user-chip merge in `mergeSnapshot`.

## Tests
- `DataStore.test.js`: hook wiring — lean refetch preserves via hook; behavior unchanged without hook.
- `__tests__/tasks.test.js`: 5 cases for `preserveUnevaluatedSummaries` (preserve on positive counter, blank on zero counter, fresh values win, no-cache passthrough, missing keys treated as unevaluated).
- Run: `bun test libs/datamanager/src/mixins/DataStore/DataStore.test.js libs/datamanager/src/stores/DataStores/__tests__/tasks.test.js` → 15 pass, 0 fail. Biome check clean on touched files. Backend untouched (ruff/tavern N/A).
- Note: Tabs suites in this lib currently fail at import on missing `react-router-dom` in a bare checkout; verified identical failure without this change (pre-existing env gap, unrelated files).

## Acceptance criteria (for QA)
1. Open a project with annotated tasks, Annotation Results column visible — values render.
2. Open any task in the labelling view, navigate back to the grid — Annotation Results still shows values, no resize needed.
3. Delete an annotation so a task has zero annotations, return to the grid — its cell correctly blanks (no stale preservation).
4. Edit annotation results, return — fresh values display (no stale preservation).
