### PR TITLE
ci: PLT-1272: Resolve gitleaks version with an authenticated API call

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -27,16 +27,25 @@ jobs:
 
       - name: install
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           arch="$(uname)_$(uname -m)"
           platform=$(echo $arch | tr '[:upper:]' '[:lower:]' )
           echo "PLATFORM=$platform" >> $GITHUB_ENV
           if [[ "${{ inputs.version }}" == "latest" ]]; then
-            echo "GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name | sed 's/^v//')" >> $GITHUB_ENV
+            # Authenticated call: unauthenticated api.github.com requests are rate-limited per IP
+            # on shared runners and silently yield `null`, producing a broken download URL.
+            version="$(gh release view --repo gitleaks/gitleaks --json tagName --jq '.tagName' | sed 's/^v//')"
           else
-            echo "GITLEAKS_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+            version="${{ inputs.version }}"
           fi
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::error::Failed to resolve gitleaks version (got '${version}')"
+            exit 1
+          fi
+          echo "GITLEAKS_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Cache gitleaks archive
         id: cache_gitleaks


### PR DESCRIPTION
## Problem

The `Linter / Gitleaks` check on #9937 failed before scanning anything:

```
Download Gitleaks null for linux_x86_64 from https://github.com/gitleaks/gitleaks/releases/download/vnull/gitleaks_null_linux_x64.tar.gz
curl: (22) The requested URL returned error: 404
```

The install step resolves the latest tag with an unauthenticated `curl https://api.github.com/.../releases/latest | jq -r .tag_name`. Unauthenticated API calls are rate-limited per IP, and shared runners exhaust that limit, so `jq` prints `null` and the job breaks with a misleading 404. It also poisons the cache key (`gitleaks-linux_x86_64-null`).

## Fix

- Resolve the version with `gh release view --repo gitleaks/gitleaks`, authenticated via `github.token` (available in reusable workflows).
- Fail fast with an explicit `::error::` if the version still comes back empty or `null`, instead of building a bogus download URL.

No change to the scan itself or to the pinned-version path (`inputs.version != "latest"`).

## Test plan

- [ ] `Linter / Gitleaks` passes on this PR
- [ ] Re-run the Gitleaks check on #9937 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrU7Kt5sHGeVFap1t2kQ5i